### PR TITLE
Add lint guiding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ pages:
 ```
 
 this error message will be given:
-```
+```shell
 The value provided for argument `number` given to container `ExampleContainer` is of type `str`. Expected type `int`
 ```
 
@@ -202,7 +202,6 @@ be of type `pathlib.Path`, the configuration parser will make sure that
 the user provided path (which is a string to begin with in configuration file,
 potentially non-absolute and relative to the configuration file itself) is
 given to the container as an absolute path, and of type `pathlib.Path`.
-
 
 ### Data input
 
@@ -317,7 +316,6 @@ be copied over to the portable `webviz` instance, and the decorated function
 will return a `pathlib.Path` instance pointing to the stored file. For most
 use cases, the decorated function `get_resource` in
 `webviz_config.webviz_store` can be imported and used.
-
 
 **Note:** The argument hashing method used for `@webvizstore` is using
 the same principles as in `@cache.memoize` from the `flask-caching` package.

--- a/webviz_config/containers/_banner_image.py
+++ b/webviz_config/containers/_banner_image.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import dash_html_components as html
 from ..webviz_assets import webviz_assets

--- a/webviz_config/containers/_example_container.py
+++ b/webviz_config/containers/_example_container.py
@@ -25,5 +25,5 @@ class ExampleContainer:
     def set_callbacks(self, app):
         @app.callback(Output(self.div_id, 'children'),
                       [Input(self.button_id, 'n_clicks')])
-        def update_output(n_clicks):
+        def update_output(n_clicks):  # pylint: disable=unused-variable
             return 'Button has been pressed {} times.'.format(n_clicks)

--- a/webviz_config/containers/_table_plotter.py
+++ b/webviz_config/containers/_table_plotter.py
@@ -227,7 +227,7 @@ a database.
         @app.callback(
             self.plot_output_callbacks,
             self.plot_input_callbacks)
-        def update_output(*args):
+        def update_output(*args):  # pylint: disable=unused-variable
             '''Updates the graph and shows/hides plot options'''
             plot_type = args[0]
             plotfunc = getattr(px._chart_types, plot_type)

--- a/webviz_config/webviz_assets.py
+++ b/webviz_config/webviz_assets.py
@@ -61,7 +61,7 @@ class WebvizAssets:
         '''
 
         @app.server.route(f'/{self._base_folder()}/<path:asset_id>')
-        def send_file(asset_id):
+        def send_file(asset_id):  # pylint: disable=unused-variable
             if asset_id in self._assets:  # Only serve white listed resources
                 path = pathlib.Path(self._assets[asset_id])
                 return flask.send_from_directory(path.parent, path.name)


### PR DESCRIPTION
- PyLint has said discovering usage of functions through decorators is outside scope. One solution is therefore to tell PyLint explicitly which decorated functions are actually used by adding `  # pylint: disable=unused-variable` on the corresponding line.