### PR TITLE
Add option for providing height/width of markdown images

### DIFF
--- a/examples/example-markdown.md
+++ b/examples/example-markdown.md
@@ -23,7 +23,7 @@ Hi from a Markdown container containing Norwegian letters (æ ø å), some
 
 #### An image with a caption
 
-![Alt text](./example_banner.png "Some caption")
+![width=40%,height=300px](./example_banner.png "Some caption")
 
 #### Quote
 

--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -45,10 +45,21 @@ class _MarkdownImageProcessor(ImageInlineProcessor):
 
         url = webviz_assets.add(image_path)
 
+        image_style = ''
+        for style_prop in image.get('alt').split(','):
+            prop, value = style_prop.split('=')
+            if prop == 'width':
+                image_style += f'width: {value};'
+            elif prop == 'height':
+                image_style += f'height: {value};'
+
+        if image_style:
+            image.set('style', image_style)
+
         image.set('src', url)
         image.set('class', '_markdown_image')
 
-        container = etree.Element('span', attrib={'style': 'display: block'})
+        container = etree.Element('span')
         container.append(image)
 
         etree.SubElement(container,
@@ -62,12 +73,20 @@ class _MarkdownImageProcessor(ImageInlineProcessor):
 class Markdown(WebvizContainer):
     '''### Include Markdown
 
+_Note:_ The markdown syntax for images has been extended to support
+(optionally) providing width and/or height for individual images.
+To specify the dimensions write e.g.
+```markdown
+![width=40%,height=300px](./example_banner.png "Some caption")
+```
+
 This container renders and includes the content from a Markdown file. Images
 are supported, and should in the markdown file be given as either relative
 paths to the markdown file itself, or absolute paths.
 
 * `markdown_file`: Path to the markdown file to render and include. Either
   absolute path or relative to the configuration file.
+
 '''
 
     ALLOWED_TAGS = [
@@ -80,9 +99,11 @@ paths to the markdown file itself, or absolute paths.
 
     ALLOWED_ATTRIBUTES = {
         '*': ['id', 'class', 'style'],
-        'img': ['src', 'alt', 'title'],
+        'img': ['src', 'alt', 'title', 'style'],
         'a': ['href', 'alt', 'title']
     }
+
+    ALLOWED_STYLES = ['display', 'width', 'height']
 
     def __init__(self, markdown_file: Path):
         self.html = bleach.clean(
@@ -93,8 +114,9 @@ paths to the markdown file itself, or absolute paths.
                                         _WebvizMarkdownExtension(
                                             base_path=markdown_file.parent
                                                                  )]),
-                        Markdown.ALLOWED_TAGS,
-                        Markdown.ALLOWED_ATTRIBUTES
+                        tags=Markdown.ALLOWED_TAGS,
+                        attributes=Markdown.ALLOWED_ATTRIBUTES,
+                        styles=Markdown.ALLOWED_STYLES
                                 )
 
     @property

--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -102,7 +102,7 @@ paths to the markdown file itself, or absolute paths.
         'a': ['href', 'alt', 'title']
     }
 
-    ALLOWED_STYLES = ['display', 'width', 'height']
+    ALLOWED_STYLES = ['width', 'height']
 
     def __init__(self, markdown_file: Path):
         self.html = bleach.clean(

--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -86,7 +86,6 @@ paths to the markdown file itself, or absolute paths.
 
 * `markdown_file`: Path to the markdown file to render and include. Either
   absolute path or relative to the configuration file.
-
 '''
 
     ALLOWED_TAGS = [


### PR DESCRIPTION
Markdown by itself does not support height/width definition of images.

Resolves #34 by utilizing existing framework where `markdown` is parsed to `html` using a plugin to the [`python-markdown` library](https://github.com/Python-Markdown/markdown).