### PR TITLE
Remove obsolete dash settings

### DIFF
--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -12,8 +12,6 @@ get_data = 'webviz_config.containers'\
 def test_data_table(dash_duo):
 
     app = dash.Dash(__name__)
-    app.css.config.serve_locally = True
-    app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     cache.init_app(app.server)
     code_file = './tests/data/example_data.csv'

--- a/tests/test_example_container.py
+++ b/tests/test_example_container.py
@@ -6,8 +6,6 @@ from webviz_config.containers import _example_container
 def test_example_container(dash_duo):
 
     app = dash.Dash(__name__)
-    app.css.config.serve_locally = True
-    app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     cache.init_app(app.server)
     title = 'Example'

--- a/tests/test_syntax_highlighter.py
+++ b/tests/test_syntax_highlighter.py
@@ -12,8 +12,6 @@ get_path = 'webviz_config.containers'\
 def test_syntax_highlighter(dash_duo):
 
     app = dash.Dash(__name__)
-    app.css.config.serve_locally = True
-    app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     cache.init_app(app.server)
     code_file = Path('./tests/data/basic_example.yaml')

--- a/tests/test_table_plotter.py
+++ b/tests/test_table_plotter.py
@@ -7,8 +7,6 @@ from webviz_config.containers import _table_plotter
 def test_table_plotter(dash_duo):
 
     app = dash.Dash(__name__)
-    app.css.config.serve_locally = True
-    app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     cache.init_app(app.server)
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -25,8 +25,6 @@ app = dash.Dash(__name__, external_stylesheets={{ external_stylesheets }})
 server = app.server
 
 app.title = '{{ title }}'
-app.css.config.serve_locally = True
-app.scripts.config.serve_locally = True
 app.config.suppress_callback_exceptions = True
 
 app.webviz_settings = {


### PR DESCRIPTION
With `dash~=1.0.0` [JS and CSS are by default served locally](https://github.com/plotly/dash/blob/master/dash/CHANGELOG.md#changed).