### PR TITLE
Add hot reload

### DIFF
--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -13,7 +13,6 @@ def write_script(args, build_directory, template_filename, output_filename):
 
     configuration['port'] = args.port
     configuration['portable'] = True if args.portable else False
-    configuration['debug'] = args.debug
     configuration['localhostonly'] = not args.not_only_localhost
 
     theme = installed_themes[args.theme]

--- a/webviz_config/command_line.py
+++ b/webviz_config/command_line.py
@@ -26,8 +26,6 @@ def main():
                                    'and saved to the given folder.')
     parser_build.add_argument('--not-only-localhost', action='store_true',
                               help='Front-end accesible on internal network')
-    parser_build.add_argument('--debug', action='store_true',
-                              help='Start the application in debug mode')
     parser_build.add_argument('--theme', type=str, default='default',
                               help='Which installed theme to use.')
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -83,4 +83,4 @@ if __name__ == '__main__':
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
     dash_auth.BasicAuth(app, {'{{ username }}': '{{ password }}'})
-    app.run_server(host={{ "'localhost'" if localhostonly else 'socket.getfqdn()'}}, port={{port}}, ssl_context={{ssl_context}}, {{'debug=True' if debug else 'dev_tools_hot_reload=True'}})
+    app.run_server(host={{ "'localhost'" if localhostonly else 'socket.getfqdn()'}}, port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)


### PR DESCRIPTION
Resolves #38. Also reduced the check time for `dash` to 1 second wrt. checking the generated app hash (default 3 seconds)

Now that hot reload in practice also works with `debug=False`, the `debug` argument flag can be removed.