### PR TITLE
Update test dependency installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 
 before_install:
   - sudo apt-get -qq update
-  - export DISPLAY=:99.0
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
-cache: pip
+dist: bionic
 
 addons:
-    chrome: stable
+  chrome: stable
+
+services:
+  - xvfb
 
 python:
   - "3.6"
@@ -13,7 +16,6 @@ matrix:
 before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 script:
   - pip install .
   - pip install .[tests]
+  - pip install dash[testing]
   - pycodestyle webviz_config
   - pytest tests
   - pushd ./docs; python build_docs.py; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - pip install --upgrade pip
 
 install:
-  - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ Then install dev requirements and run pytest:
 
 ```bash
 pip install .[tests]
+pip install dash[testing]
 pytest tests
 ```
+
+The second of these commands appears to be necessary as long as
+[this `pip` issue is open](https://github.com/pypa/pip/issues/4957).
 
 Linting can be checked by:
 


### PR DESCRIPTION
Following the same changes as in https://github.com/equinor/webviz-subsurface-components/pull/12 when it comes to install now optional dash test dependencies.

In addition:
- Update chrome driver in `.travis.yml` (since Travis has jumped to Chrome version 76).
- Update to _Ubuntu Bionic 18.04_ (from default Travis Ubuntu Trusty 14.04) as that [is now the recommended way of using `xvfb` in Travis](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).