### PR TITLE
Remove plotly express standalone dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'jinja2~=2.10',
         'markdown~=3.0.1',
         'pandas~=0.24.1',
-        'plotly-express~=0.1.3',
         'pyarrow~=0.11.1',
         'pyyaml~=5.1'
     ],

--- a/webviz_config/containers/_table_plotter.py
+++ b/webviz_config/containers/_table_plotter.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import dash_html_components as html
 import dash_core_components as dcc
 from dash.dependencies import Input, Output
-import plotly_express as px
+import plotly.express as px
 from . import WebvizContainer
 from ..webviz_store import webvizstore
 from ..common_cache import cache


### PR DESCRIPTION
Plotly Express is now built-in to Plotly Python so there is no need to have it as a standalone dependency. 
https://medium.com/plotly/plotly-py-4-0-is-here-offline-only-express-first-displayable-anywhere-fc444e5659ee
 