### PR TITLE
Prefix callback functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ There is a [data download button](#override-container-toolbar) provided by
 the `WebvizContainer` class. However, it will only appear if the corresponding
 callback is set. A typical data download callback will look like
 
-```
+```python
 @app.callback(self.container_data_output,
               [self.container_data_requested])
 def _user_download_data(data_requested):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ class ExampleContainer(WebvizContainer):
     def set_callbacks(self, app):
         @app.callback(Output(self.div_id, 'children'),
                       [Input(self.button_id, 'n_clicks')])
-        def update_output(n_clicks):
+        def _update_output(n_clicks):
             return f'Button has been pressed {n_clicks} times.'
 ```
 
@@ -141,7 +141,7 @@ callback is set. A typical data download callback will look like
 ```
         @app.callback(self.container_data_output,
                       [self.container_data_requested])
-        def cb_user_download_data(data_requested):
+        def _user_download_data(data_requested):
             return WebvizContainer.container_data_compress(
                 [{'filename': 'some_file.txt',
                   'content': 'Some download data'}]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,13 +139,13 @@ the `WebvizContainer` class. However, it will only appear if the corresponding
 callback is set. A typical data download callback will look like
 
 ```
-        @app.callback(self.container_data_output,
-                      [self.container_data_requested])
-        def _user_download_data(data_requested):
-            return WebvizContainer.container_data_compress(
-                [{'filename': 'some_file.txt',
-                  'content': 'Some download data'}]
-            ) if data_requested else ''
+@app.callback(self.container_data_output,
+              [self.container_data_requested])
+def _user_download_data(data_requested):
+    return WebvizContainer.container_data_compress(
+        [{'filename': 'some_file.txt',
+          'content': 'Some download data'}]
+    ) if data_requested else ''
 ```
 By letting the container define the callback, the container author is able
 to utilize the whole callback machinery, including e.g. state of the individual

--- a/webviz_config/containers/_example_container.py
+++ b/webviz_config/containers/_example_container.py
@@ -26,5 +26,5 @@ class ExampleContainer(WebvizContainer):
     def set_callbacks(self, app):
         @app.callback(Output(self.div_id, 'children'),
                       [Input(self.button_id, 'n_clicks')])
-        def update_output(n_clicks):
+        def _update_output(n_clicks):
             return 'Button has been pressed {} times.'.format(n_clicks)

--- a/webviz_config/containers/_table_plotter.py
+++ b/webviz_config/containers/_table_plotter.py
@@ -253,7 +253,7 @@ a database.
         @app.callback(
             self.plot_output_callbacks,
             self.plot_input_callbacks)
-        def update_output(*args):
+        def _update_output(*args):
             '''Updates the graph and shows/hides plot options'''
             plot_type = args[0]
             plotfunc = getattr(px._chart_types, plot_type)

--- a/webviz_config/webviz_assets.py
+++ b/webviz_config/webviz_assets.py
@@ -63,7 +63,7 @@ class WebvizAssets:
         '''
 
         @app.server.route(f'/{self._base_folder()}/<path:asset_id>')
-        def send_file(asset_id):
+        def _send_file(asset_id):
             if asset_id in self._assets:  # Only serve white listed resources
                 path = pathlib.Path(self._assets[asset_id])
                 return flask.send_from_directory(path.parent, path.name)


### PR DESCRIPTION
`pylint` does not recognize that decorated callback functions are used within `dash`, and therefore falsely reports them as unused. This is solved by prefixing them with `_`, which at the same time indicates that these callback functions are defined (and used) within the container.