### PR TITLE
Disallow eval in CSP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'pandas~=0.24',
         'pyarrow~=0.11',
         'pyyaml~=5.1',
-        'webviz-core-components>=0.0.3'
+        'webviz-core-components>=0.0.7'
     ],
     tests_require=tests_requires,
     extras_require={'tests': tests_requires},

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'pandas~=0.24',
         'pyarrow~=0.11',
         'pyyaml~=5.1',
-        'webviz-core-components>=0.0.7'
+        'webviz-core-components>=0.0.8'
     ],
     tests_require=tests_requires,
     extras_require={'tests': tests_requires},

--- a/webviz_config/containers/_table_plotter.py
+++ b/webviz_config/containers/_table_plotter.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import dash_html_components as html
 import dash_core_components as dcc
 from dash.dependencies import Input, Output
+import webviz_core_components as wcc
 import plotly.express as px
 from . import WebvizContainer
 from ..webviz_store import webvizstore
@@ -271,8 +272,7 @@ a database.
                     style=self.style_selectors,
                     children=self.plot_option_layout()),
                 html.Div(style={'height': '100%'},
-                         children=dcc.Graph(id=self.graph_id, config={
-                             'responsive': 'true'})
+                         children=wcc.Graph(id=self.graph_id)
                          ),
                 html.Div(children=self.filter_layout())
             ])

--- a/webviz_config/themes/_theme_class.py
+++ b/webviz_config/themes/_theme_class.py
@@ -11,9 +11,9 @@ class WebvizConfigTheme:
                      'connect-src': "'self'",
                      'prefetch-src': "'self'",
                      'style-src': ["'self'", "'unsafe-inline'"],   # [1]
-                     'script-src': ["'self'", "'unsafe-eval'",     # [2]
+                     'script-src': ["'self'",
                                     ("'sha256-jZlsGVOhUAIcH+4PV"
-                                     "s7QuGZkthRMgvT2n0ilH6/zTM0='")],  # [3]
+                                     "s7QuGZkthRMgvT2n0ilH6/zTM0='")],  # [2]
                      'img-src': ["'self'", 'data:'],
                      'navigate-to': "'self'",
                      'base-uri': "'self'",
@@ -28,9 +28,7 @@ class WebvizConfigTheme:
         These are the current exceptions to the most strict CSP setup:
             [1] unsafe-inline for style still needed by plotly
                 (https://github.com/plotly/plotly.js/issues/2355)
-            [2] unsafe-eval still needed by plotly
-                (https://github.com/plotly/plotly.js/issues/897)
-            [3] https://github.com/plotly/dash/issues/630
+            [2] https://github.com/plotly/dash/issues/630
         '''
 
         self._feature_policy = {'camera': "'none'",


### PR DESCRIPTION
Follow-up of https://github.com/equinor/webviz-core-components/pull/12 on the `webviz-config` side. Responsibility for downloading and installing `plotly-cartesian` will be transferred to `webviz-core-components`.

- [X] Disallow `eval` and similar commands in CSP.
- [X] Bump `webviz-core-components` version.
- [X] Move from `dcc.Graph` to `wcc.Graph`.