### PR TITLE
Add requests dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'bleach~=3.1',
         'cryptography~=2.4',
         'dash-auth~=1.3',
+        'requests',  # While waiting for dep. fix in dash-auth >= 1.4 on pypi
         'flask-caching~=1.4',
         'flask-talisman~=0.6',
         'jinja2~=2.10',


### PR DESCRIPTION
📦 Need to add `requests` package as a direct dependency as long as https://github.com/plotly/dash-auth/issues/87 and the PR-solution https://github.com/plotly/dash-auth/pull/89 is not released on https://pypi.org/project/dash-auth/. 

Currently the built  [Dash docker base image](https://github.com/equinor/webviz-docker), built from `python:3.7-slim`, fails due to missing `requests` package. 💻 