### PR TITLE
Use one-time-tokens and open browser automatically

### DIFF
--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -9,11 +9,11 @@ pages:
    content:
     - container: BannerImage
       image: ./example_banner.png
-      title: My banner image 
+      title: My banner image
     - Webviz created from configuration file.
     - Some other text, potentially with strange letters like Åre, Smørbukk Sør.
 
- - title: Markdown exampled
+ - title: Markdown example
    content:
     - container: Markdown
       markdown_file: ./example-markdown.md

--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -9,11 +9,11 @@ pages:
    content:
     - container: BannerImage
       image: ./example_banner.png
-      title: My banner image
+      title: My banner image 
     - Webviz created from configuration file.
     - Some other text, potentially with strange letters like Åre, Smørbukk Sør.
 
- - title: Markdown example
+ - title: Markdown exampled
    content:
     - container: Markdown
       markdown_file: ./example-markdown.md

--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -2,9 +2,6 @@
 # The configuration files uses YAML (https://en.wikipedia.org/wiki/YAML).
 
 title: Reek Webviz Demonstration
-username: some_username
-password: some_password
-
 
 pages:
 

--- a/examples/demo_portable.yaml
+++ b/examples/demo_portable.yaml
@@ -3,9 +3,6 @@
 
 title: Reek Webviz Demonstration
 
-username: some_username
-password: some_password
-
 pages:
 
  - title: Front page

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ setup(
         'dash~=1.1',
         'bleach~=3.1',
         'cryptography~=2.4',
-        'dash-auth~=1.3',
-        'requests',  # While waiting for dep. fix in dash-auth >= 1.4 on pypi
         'flask-caching~=1.4',
         'flask-talisman~=0.6',
         'jinja2~=2.10',

--- a/webviz_config/__init__.py
+++ b/webviz_config/__init__.py
@@ -1,5 +1,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
+from ._webviz_ott import LocalhostLogin
+
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:

--- a/webviz_config/__init__.py
+++ b/webviz_config/__init__.py
@@ -1,6 +1,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
-from ._webviz_ott import LocalhostLogin
+from ._localhost_token import LocalhostToken
+from ._localhost_open_browser import LocalhostOpenBrowser
 
 try:
     __version__ = get_distribution(__name__).version

--- a/webviz_config/__init__.py
+++ b/webviz_config/__init__.py
@@ -2,6 +2,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 
 from ._localhost_token import LocalhostToken
 from ._localhost_open_browser import LocalhostOpenBrowser
+from ._is_reload_process import is_reload_process
 
 try:
     __version__ = get_distribution(__name__).version

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import subprocess
 from yaml import YAMLError
-from ._webviz_ott import LocalhostLogin
+from ._localhost_token import LocalhostToken
 from ._config_parser import ParserError
 from ._write_script import write_script
 from .themes import installed_themes
@@ -58,17 +58,16 @@ def build_webviz(args):
                   'Finished data extraction. All output saved.'
                   '\033[0m')
 
-        ott = None if args.portable else LocalhostLogin.generate_token()
+        ott = None if args.portable else LocalhostToken.generate_token()
         cookie_token = None if args.portable \
-            else LocalhostLogin.generate_token()
+            else LocalhostToken.generate_token()
 
         non_default_assets = write_script(args,
                                           build_directory,
                                           'webviz_template.py.jinja2',
                                           BUILD_FILENAME,
                                           ott,
-                                          cookie_token,
-                                          open_browser=True)
+                                          cookie_token)
 
         for asset in non_default_assets:
             shutil.copy(asset, os.path.join(build_directory, 'assets'))

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -58,22 +58,16 @@ def build_webviz(args):
                   'Finished data extraction. All output saved.'
                   '\033[0m')
 
-        ott = None if args.portable else LocalhostToken.generate_token()
-        cookie_token = None if args.portable \
-            else LocalhostToken.generate_token()
-
         non_default_assets = write_script(args,
                                           build_directory,
                                           'webviz_template.py.jinja2',
-                                          BUILD_FILENAME,
-                                          ott,
-                                          cookie_token)
+                                          BUILD_FILENAME)
 
         for asset in non_default_assets:
             shutil.copy(asset, os.path.join(build_directory, 'assets'))
 
         if not args.portable:
-            run_webviz(args, build_directory, ott, cookie_token)
+            run_webviz(args, build_directory)
 
     finally:
         if not args.portable:
@@ -81,7 +75,7 @@ def build_webviz(args):
             shutil.rmtree(build_directory)
 
 
-def run_webviz(args, build_directory, ott, cookie_token):
+def run_webviz(args, build_directory):
 
     print(' \n\033[92m'
           ' Starting up your webviz application. Please wait...'
@@ -101,9 +95,7 @@ def run_webviz(args, build_directory, ott, cookie_token):
                 write_script(args,
                              build_directory,
                              'webviz_template.py.jinja2',
-                             BUILD_FILENAME,
-                             ott,
-                             cookie_token)
+                             BUILD_FILENAME)
                 print('\033[1m\033[94m'
                       'Rebuilt webviz dash app from configuration file'
                       '\033[0m')

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -1,6 +1,5 @@
 import os
 import time
-import socket
 import shutil
 import tempfile
 import subprocess
@@ -77,14 +76,8 @@ def build_webviz(args):
 
 def run_webviz(args, build_directory):
 
-    hostname = socket.getfqdn() if args.not_only_localhost else 'localhost'
-
     print(' \n\033[92m'
-          ' Initializing your webviz application. Go to \n'
-          f' https://{hostname}:{args.port} \n'
-          ' in order to browse it. The files are hosted from '
-          f' {build_directory}\n\n'
-          ' To shut down the application, press CTRL+C at any time.'
+          ' Starting up your webviz application. Please wait...'
           ' \033[0m\n')
 
     app_process = subprocess.Popen(['python3', BUILD_FILENAME],

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -92,10 +92,8 @@ def run_webviz(args, build_directory):
         try:
             if lastmtime != os.path.getmtime(args.yaml_file):
                 lastmtime = os.path.getmtime(args.yaml_file)
-                write_script(args,
-                             build_directory,
-                             'webviz_template.py.jinja2',
-                             BUILD_FILENAME)
+                write_script(args, build_directory,
+                             'webviz_template.py.jinja2', BUILD_FILENAME)
                 print('\033[1m\033[94m'
                       'Rebuilt webviz dash app from configuration file'
                       '\033[0m')

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -59,7 +59,8 @@ def build_webviz(args):
                   '\033[0m')
 
         ott = None if args.portable else LocalhostLogin.generate_token()
-        cookie_token = None if args.portable else LocalhostLogin.generate_token()
+        cookie_token = None if args.portable \
+            else LocalhostLogin.generate_token()
 
         non_default_assets = write_script(args,
                                           build_directory,

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -66,7 +66,8 @@ def build_webviz(args):
                                           'webviz_template.py.jinja2',
                                           BUILD_FILENAME,
                                           ott,
-                                          cookie_token)
+                                          cookie_token,
+                                          open_browser=True)
 
         for asset in non_default_assets:
             shutil.copy(asset, os.path.join(build_directory, 'assets'))

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 import subprocess
 from yaml import YAMLError
-from ._localhost_token import LocalhostToken
 from ._config_parser import ParserError
 from ._write_script import write_script
 from .themes import installed_themes

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -166,13 +166,6 @@ class ConfigParser:
         else:
             container_settings = self.configuration['container_settings']
 
-        for mandatory_key in ['password', 'username']:
-            if mandatory_key not in self.configuration:
-                raise ParserError(('\033[91m'
-                                   'The configuration file does not '
-                                   f'have {mandatory_key} set.'
-                                   '\033[0m'))
-
         if 'title' not in self.configuration:
             self.configuration['title'] = 'Webviz - Powered by Dash'
 

--- a/webviz_config/_is_reload_process.py
+++ b/webviz_config/_is_reload_process.py
@@ -1,0 +1,27 @@
+import os
+
+def is_reload_process():
+    '''Within the flask reload machinery, it is not straight forward to know
+    if the code is run as the main process (i.e. the process the user directly
+    started), or if the code is a "hot reload process" (see Flask
+    documentation).
+
+    This utility function will use the fact that the reload process is started
+    by the main process, and then utilize environment variables to tell which
+    of the two actually runs.
+
+    WARNING: For this function to work, it is essential that it is called in
+    the main process (which for all practical use cases should be the case,
+    since it is the same code that runs for both the main and reload process).
+
+    Note that environment variables set dynamically are only seen by the
+    running process and child processes (if any).
+    '''
+
+    if os.environ.get('WEBVIZ_MAIN_PID') == str(os.getppid()):
+        reload_process = True
+    else:
+        os.environ[f'WEBVIZ_MAIN_PID'] = str(os.getpid())
+        reload_process = False
+
+    return reload_process

--- a/webviz_config/_is_reload_process.py
+++ b/webviz_config/_is_reload_process.py
@@ -1,27 +1,19 @@
 import os
 
+
 def is_reload_process():
     '''Within the flask reload machinery, it is not straight forward to know
     if the code is run as the main process (i.e. the process the user directly
     started), or if the code is a "hot reload process" (see Flask
     documentation).
 
-    This utility function will use the fact that the reload process is started
-    by the main process, and then utilize environment variables to tell which
-    of the two actually runs.
-
-    WARNING: For this function to work, it is essential that it is called in
-    the main process (which for all practical use cases should be the case,
-    since it is the same code that runs for both the main and reload process).
-
-    Note that environment variables set dynamically are only seen by the
-    running process and child processes (if any).
+    This utility function will use the fact that the reload process
+    sets an environment variable WERKZEUG_RUN_MAIN.
     '''
 
-    if os.environ.get('WEBVIZ_MAIN_PID') == str(os.getppid()):
+    if os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         reload_process = True
     else:
-        os.environ[f'WEBVIZ_MAIN_PID'] = str(os.getpid())
         reload_process = False
 
     return reload_process

--- a/webviz_config/_localhost_open_browser.py
+++ b/webviz_config/_localhost_open_browser.py
@@ -4,6 +4,8 @@ import urllib
 import threading
 import webbrowser
 
+from ._is_reload_process import is_reload_process
+
 
 class LocalhostOpenBrowser:
 
@@ -11,11 +13,10 @@ class LocalhostOpenBrowser:
         self._port = port
         self._token = token
 
-        # See Werkzeug documentation. During a flask reload process,
-        # the WERKZEUG_RUN_MAIN environment variable is set. During
-        # the initial load however it is not set, which is the appropriate time
-        # to open the app in the browser.
-        if os.environ.get('WERKZEUG_RUN_MAIN') is None:
+        self._login_link = f'https://localhost:{self._port}?ott={self._token}'
+
+        if not is_reload_process():
+            # Only open new browser tab if not a reload process
             threading.Thread(target=self._timer).start()
 
     def _timer(self):
@@ -32,8 +33,11 @@ class LocalhostOpenBrowser:
 
             time.sleep(1)
 
-        print('WARNING: Webviz application still not ready after {TIMEOUT}s.'
-              'Will not open browser automatically.')
+        print(
+            f'WARNING: Webviz application still not ready after {TIMEOUT}s.\n'
+            'Will not open browser automatically. Your private login link:\n'
+            f'{self._login_link}'
+        )
 
     def _app_ready(self):
         '''Check if the flask instance is ready.
@@ -66,6 +70,4 @@ class LocalhostOpenBrowser:
               ' Press CTRL+C in this terminal window to stop the application.'
               ' \033[0m\n')
 
-        webbrowser.open_new_tab(
-            f'https://localhost:{self._port}?ott={self._token}'
-        )
+        webbrowser.open_new_tab(self._login_link)

--- a/webviz_config/_localhost_open_browser.py
+++ b/webviz_config/_localhost_open_browser.py
@@ -1,0 +1,73 @@
+import os
+import time
+import urllib
+import threading
+import webbrowser
+
+
+class LocalhostOpenBrowser:
+
+    def __init__(self, port, token):
+        self._port = port
+        self._token = token
+
+        # See Werkzeug documentation. During a flask reload process,
+        # the WERKZEUG_RUN_MAIN environment variable is set. During
+        # the initial load however it is not set, which is the appropriate time
+        # to open the app in the browser.
+        if os.environ.get('WERKZEUG_RUN_MAIN') is None:
+            threading.Thread(target=self._timer).start()
+
+    def _timer(self):
+        '''Waits until the app is ready, and then opens the page
+        in the default browser.
+        '''
+
+        TIMEOUT = 120  # maximum number of seconds to wait before timeout
+
+        for _ in range(TIMEOUT):
+            if self._app_ready():
+                self._open_new_tab()
+                return
+
+            time.sleep(1)
+
+        print('WARNING: Webviz application still not ready after {TIMEOUT}s.'
+              'Will not open browser automatically.')
+
+    def _app_ready(self):
+        '''Check if the flask instance is ready.
+        '''
+
+        no_proxy_env = os.environ.get('NO_PROXY')
+        os.environ['NO_PROXY'] = 'localhost'
+
+        try:
+            with urllib.request.urlopen(f'http://localhost:{self._port}') \
+                    as resp:
+                response.read()
+            app_ready = True
+        except urllib.error.URLError as err:
+            # The flask instance has not started
+            app_ready = False
+        except ConnectionResetError as err:
+            # The flask instance has started but (correctly) abort
+            # request due to "401 Unauthorized"
+            app_ready = True
+        finally:
+            os.environ['NO_PROXY'] = no_proxy_env if no_proxy_env else ''
+
+        return app_ready
+
+    def _open_new_tab(self):
+        '''Open the url (with token) in the default browser.
+        '''
+
+        print(' \n\033[92m'
+              ' Opening the application in your default browser.\n'
+              ' Press CTRL+C in this terminal window to stop the application.'
+              ' \033[0m\n')
+
+        webbrowser.open_new_tab(
+            f'https://localhost:{self._port}?ott={self._token}'
+        )

--- a/webviz_config/_localhost_open_browser.py
+++ b/webviz_config/_localhost_open_browser.py
@@ -43,14 +43,14 @@ class LocalhostOpenBrowser:
         os.environ['NO_PROXY'] = 'localhost'
 
         try:
-            with urllib.request.urlopen(f'http://localhost:{self._port}') \
-                    as resp:
-                response.read()
+            urllib.request.urlopen(
+                urllib.request.Request(f'http://localhost:{self._port}')
+            )
             app_ready = True
-        except urllib.error.URLError as err:
+        except urllib.error.URLError:
             # The flask instance has not started
             app_ready = False
-        except ConnectionResetError as err:
+        except ConnectionResetError:
             # The flask instance has started but (correctly) abort
             # request due to "401 Unauthorized"
             app_ready = True

--- a/webviz_config/_localhost_open_browser.py
+++ b/webviz_config/_localhost_open_browser.py
@@ -43,9 +43,7 @@ class LocalhostOpenBrowser:
         os.environ['NO_PROXY'] = 'localhost'
 
         try:
-            urllib.request.urlopen(
-                urllib.request.Request(f'http://localhost:{self._port}')
-            )
+            urllib.request.urlopen(f'http://localhost:{self._port}')  # nosec
             app_ready = True
         except urllib.error.URLError:
             # The flask instance has not started

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -35,13 +35,13 @@ class LocalhostToken:
             # when visiting the localhost app the first time.
             self._ott = \
                 os.environ['WEBVIZ_OTT'] = \
-                    LocalhostToken.generate_token()
+                LocalhostToken.generate_token()
 
             # This is the cookie token set in the users browser after
             # successfully providing the one time token
             self._cookie_token = \
                 os.environ['WEBVIZ_COOKIE_TOKEN'] = \
-                    LocalhostToken.generate_token()
+                LocalhostToken.generate_token()
 
         else:
             self._ott = os.environ['WEBVIZ_OTT']

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -28,12 +28,12 @@ class LocalhostToken:
 
         # This is the cookie token set in the users browser after
         # successfully providing the one time token
-        self._cookie_token = LocalhostLogin.generate_token() \
+        self._cookie_token = LocalhostToken.generate_token() \
             if cookie_token is None else cookie_token
 
         # The one time token user has to provide when visiting the
         # localhost app the first time.
-        self._ott = LocalhostLogin.generate_token() if ott is None else ott
+        self._ott = LocalhostToken.generate_token() if ott is None else ott
         self._ott_validated = False
 
         self.set_request_decorators()

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -5,6 +5,7 @@ import flask
 
 from ._is_reload_process import is_reload_process
 
+
 class LocalhostToken:
     '''Uses a method similar to jupyter notebook (however, here we do it over
     https in addition). This method is only used during interactive usage on

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -2,7 +2,26 @@ import secrets
 import flask
 
 
-class LocalhostLogin:
+class LocalhostToken:
+    '''Uses a method similar to jupyter notebook (however, here we do it over
+    https in addition). This method is only used during interactive usage on
+    localhost, and the workflow is as follows:
+
+    - During the flask app building, a one-time-token (ott) and a cookie_token
+      is generated.
+    - When the app is ready, the user needs to "login" using this
+      one-time-token in the url (https://localhost:{port}?ott={token})
+    - If ott is valid - a cookie with a separate token is set, and the
+      one-time-token is discarded. The cookie is then used for subsequent
+      requests.
+
+    If the user fails both providing a valid one-time-token and a valid cookie
+    token, all localhost requests gets a 401.
+
+    If the app is in non-portable mode, the one-time-token and
+    cookie token  are reused on app reload (in order to ensure live reload
+    works without requiring new login).
+    '''
 
     def __init__(self, app, ott=None, cookie_token=None):
         self._app = app

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -1,6 +1,9 @@
+import os
 import secrets
+
 import flask
 
+from ._is_reload_process import is_reload_process
 
 class LocalhostToken:
     '''Uses a method similar to jupyter notebook (however, here we do it over
@@ -23,19 +26,27 @@ class LocalhostToken:
     works without requiring new login).
     '''
 
-    def __init__(self, app, ott=None, cookie_token=None):
+    def __init__(self, app):
         self._app = app
 
-        # This is the cookie token set in the users browser after
-        # successfully providing the one time token
-        self._cookie_token = LocalhostToken.generate_token() \
-            if cookie_token is None else cookie_token
+        if not is_reload_process():
+            # One time token (per run) user has to provide
+            # when visiting the localhost app the first time.
+            self._ott = \
+                os.environ['WEBVIZ_OTT'] = \
+                    LocalhostToken.generate_token()
 
-        # The one time token user has to provide when visiting the
-        # localhost app the first time.
-        self._ott = LocalhostToken.generate_token() if ott is None else ott
+            # This is the cookie token set in the users browser after
+            # successfully providing the one time token
+            self._cookie_token = \
+                os.environ['WEBVIZ_COOKIE_TOKEN'] = \
+                    LocalhostToken.generate_token()
+
+        else:
+            self._ott = os.environ['WEBVIZ_OTT']
+            self._cookie_token = os.environ['WEBVIZ_COOKIE_TOKEN']
+
         self._ott_validated = False
-
         self.set_request_decorators()
 
     @staticmethod

--- a/webviz_config/_webviz_ott.py
+++ b/webviz_config/_webviz_ott.py
@@ -30,7 +30,7 @@ class LocalhostLogin:
     def set_request_decorators(self):
 
         @self._app.before_request
-        def check_for_ott_or_cookie():
+        def _check_for_ott_or_cookie():
             if not self._ott_validated \
                     and self._ott == flask.request.args.get('ott'):
                 self._ott_validated = True
@@ -43,7 +43,7 @@ class LocalhostLogin:
                 flask.abort(401)
 
         @self._app.after_request
-        def set_cookie_token_in_response(response):
+        def _set_cookie_token_in_response(response):
             if 'set_cookie_token' in flask.g and flask.g.set_cookie_token:
                 response.set_cookie(
                     key='cookie_token',

--- a/webviz_config/_webviz_ott.py
+++ b/webviz_config/_webviz_ott.py
@@ -1,0 +1,34 @@
+import secrets
+import flask
+
+class LocalhostLogin:
+    
+    def __init__(self, app):
+        self._app = app
+        self._cookie_token = secrets.token_urlsafe()
+
+        self._ott = secrets.token_urlsafe()
+        self._ott_used = False
+
+        self.set_callbacks(self._app)
+
+    @property
+    def one_time_token(self):
+        return self._ott
+
+    def set_callbacks(self, app):
+
+        @app.before_request
+        def before_request_func():
+            if not self._ott_used and self._ott == flask.request.args.get('ott'):
+                self._ott_used = True
+                flask.g.set_cookie_token = True
+            elif self._cookie_token != flask.request.cookies.get('cookie_token'):
+                flask.abort(401)
+
+        @app.after_request
+        def set_language_cookie(response):
+            if 'set_cookie_token' in flask.g and flask.g.set_cookie_token:
+                response.set_cookie('cookie_token', value=self._cookie_token)
+
+            return response

--- a/webviz_config/_webviz_ott.py
+++ b/webviz_config/_webviz_ott.py
@@ -20,7 +20,7 @@ class LocalhostLogin:
 
     @staticmethod
     def generate_token():
-        return secrets.token_urlsafe()
+        return secrets.token_urlsafe(nbytes=64)
 
     @property
     def one_time_token(self):

--- a/webviz_config/_webviz_ott.py
+++ b/webviz_config/_webviz_ott.py
@@ -1,8 +1,9 @@
 import secrets
 import flask
 
+
 class LocalhostLogin:
-    
+
     def __init__(self, app, ott=None, cookie_token=None):
         self._app = app
 
@@ -30,11 +31,13 @@ class LocalhostLogin:
 
         @self._app.before_request
         def check_for_ott_or_cookie():
-            if not self._ott_validated and self._ott == flask.request.args.get('ott'):
+            if not self._ott_validated \
+                    and self._ott == flask.request.args.get('ott'):
                 self._ott_validated = True
                 flask.g.set_cookie_token = True
                 return flask.redirect(flask.request.base_url)
-            elif self._cookie_token == flask.request.cookies.get('cookie_token'):
+            elif self._cookie_token \
+                    == flask.request.cookies.get('cookie_token'):
                 self._ott_validated = True
             else:
                 flask.abort(401)

--- a/webviz_config/_webviz_ott.py
+++ b/webviz_config/_webviz_ott.py
@@ -5,29 +5,34 @@ class LocalhostLogin:
     
     def __init__(self, app):
         self._app = app
+
+        # This is the cookie token set in the users browser after
+        # successfully providing the one time token
         self._cookie_token = secrets.token_urlsafe()
 
+        # The one time token user has to provide when visiting the
+        # localhost app the first time.
         self._ott = secrets.token_urlsafe()
         self._ott_used = False
 
-        self.set_callbacks(self._app)
+        self.set_request_decorators()
 
     @property
     def one_time_token(self):
         return self._ott
 
-    def set_callbacks(self, app):
+    def set_request_decorators(self):
 
-        @app.before_request
-        def before_request_func():
+        @self._app.before_request
+        def check_for_ott_or_cookie():
             if not self._ott_used and self._ott == flask.request.args.get('ott'):
                 self._ott_used = True
                 flask.g.set_cookie_token = True
             elif self._cookie_token != flask.request.cookies.get('cookie_token'):
                 flask.abort(401)
 
-        @app.after_request
-        def set_language_cookie(response):
+        @self._app.after_request
+        def set_cookie_token_in_response(response):
             if 'set_cookie_token' in flask.g and flask.g.set_cookie_token:
                 response.set_cookie('cookie_token', value=self._cookie_token)
 

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -7,7 +7,7 @@ from ._certificate import create_certificate, SERVER_KEY_FILENAME, \
 
 
 def write_script(args, build_directory, template_filename, output_filename,
-                 ott=None, cookie_token=None, open_browser=False):
+                 ott=None, cookie_token=None):
 
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration
@@ -17,7 +17,6 @@ def write_script(args, build_directory, template_filename, output_filename,
 
     configuration['ott'] = ott
     configuration['cookie_token'] = cookie_token
-    configuration['open_browser'] = open_browser
 
     theme = installed_themes[args.theme]
     configuration['csp'] = theme.csp

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -7,7 +7,7 @@ from ._certificate import create_certificate, SERVER_KEY_FILENAME, \
 
 
 def write_script(args, build_directory, template_filename, output_filename,
-    ott=None, cookie_token=None, open_browser=False):
+                 ott=None, cookie_token=None, open_browser=False):
 
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -7,7 +7,7 @@ from ._certificate import create_certificate, SERVER_KEY_FILENAME, \
 
 
 def write_script(args, build_directory, template_filename, output_filename,
-    ott=None, cookie_token=None):
+    ott=None, cookie_token=None, open_browser=False):
 
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration
@@ -17,6 +17,7 @@ def write_script(args, build_directory, template_filename, output_filename,
 
     configuration['ott'] = ott
     configuration['cookie_token'] = cookie_token
+    configuration['open_browser'] = open_browser
 
     theme = installed_themes[args.theme]
     configuration['csp'] = theme.csp

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -6,14 +6,17 @@ from ._certificate import create_certificate, SERVER_KEY_FILENAME, \
                           SERVER_CRT_FILENAME
 
 
-def write_script(args, build_directory, template_filename, output_filename):
+def write_script(args, build_directory, template_filename, output_filename,
+    ott=None, cookie_token=None):
 
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration
 
     configuration['port'] = args.port
     configuration['portable'] = True if args.portable else False
-    configuration['localhostonly'] = not args.not_only_localhost
+
+    configuration['ott'] = ott
+    configuration['cookie_token'] = cookie_token
 
     theme = installed_themes[args.theme]
     configuration['csp'] = theme.csp

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -6,17 +6,13 @@ from ._certificate import create_certificate, SERVER_KEY_FILENAME, \
                           SERVER_CRT_FILENAME
 
 
-def write_script(args, build_directory, template_filename, output_filename,
-                 ott=None, cookie_token=None):
+def write_script(args, build_directory, template_filename, output_filename):
 
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration
 
     configuration['port'] = args.port
     configuration['portable'] = True if args.portable else False
-
-    configuration['ott'] = ott
-    configuration['cookie_token'] = cookie_token
 
     theme = installed_themes[args.theme]
     configuration['csp'] = theme.csp

--- a/webviz_config/command_line.py
+++ b/webviz_config/command_line.py
@@ -24,8 +24,6 @@ def main():
                               metavar='OUTPUTFOLDER',
                               help='A portable webviz instance will created '
                                    'and saved to the given folder.')
-    parser_build.add_argument('--not-only-localhost', action='store_true',
-                              help='Front-end accesible on internal network')
     parser_build.add_argument('--theme', type=str, default='default',
                               help='Which installed theme to use.')
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -107,11 +107,7 @@ if __name__ == '__main__':
     # This part is ignored when the webviz app is started
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
-    token = webviz_config.LocalhostToken(
-                app.server,
-                ott={{'"' + ott + '"' if ott else None}},
-                cookie_token={{'"' + cookie_token + '"' if cookie_token else None}}
-            ).one_time_token
+    token = webviz_config.LocalhostToken(app.server).one_time_token
 
     webviz_config.LocalhostOpenBrowser({{port}}, token)
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -9,10 +9,10 @@ import os.path as path
 from pathlib import Path, PosixPath
 
 import dash
-import dash_auth
 import dash_core_components as dcc
 import dash_html_components as html
 from flask_talisman import Talisman
+import webviz_config
 from webviz_config.common_cache import cache
 from webviz_config.webviz_store import webviz_storage
 from webviz_config.webviz_assets import webviz_assets
@@ -106,5 +106,7 @@ if __name__ == '__main__':
     # This part is ignored when the webviz app is started
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
-    dash_auth.BasicAuth(app, {'{{ username }}': '{{ password }}'})
+    token = webviz_config.LocalhostLogin(app.server).one_time_token
+    print(f'https://localhost:8050?ott={token}')
+
     app.run_server(host={{ "'localhost'" if localhostonly else 'socket.getfqdn()'}}, port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -107,6 +107,12 @@ if __name__ == '__main__':
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
     token = webviz_config.LocalhostLogin(app.server).one_time_token
-    print(f'https://localhost:8050?ott={token}')
 
-    app.run_server(host={{ "'localhost'" if localhostonly else 'socket.getfqdn()'}}, port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)
+    print(' \n\033[92m'
+          ' You can go to\n'
+          f' https://localhost:{{port}}?ott={token}\n'
+          ' in order to browse the built app. This link is only valid once.\n'
+          ' To shut down the application, press CTRL+C at any time.'
+          ' \033[0m\n')
+
+    app.run_server(host='localhost', port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -4,7 +4,7 @@
 
 import logging
 import logging.config
-import socket
+import webbrowser
 import os.path as path
 from pathlib import Path, PosixPath
 
@@ -113,10 +113,12 @@ if __name__ == '__main__':
             ).one_time_token
 
     print(' \n\033[92m'
-          ' You can go to\n'
-          f' https://localhost:{{port}}?ott={token}\n'
-          ' in order to browse the built app. This link is only valid once.\n'
-          ' To shut down the application, press CTRL+C at any time.'
+          ' Webviz ready. Opening the application in your default browser.\n'
+          ' Press CTRL+C in this terminal window to shut down the application.'
           ' \033[0m\n')
+
+    {% if open_browser -%}
+    webbrowser.open_new_tab(f'https://localhost:{{port}}?ott={token}\n')
+    {%- endif %}
 
     app.run_server(host='localhost', port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -107,19 +107,20 @@ if __name__ == '__main__':
     # This part is ignored when the webviz app is started
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
-    token = webviz_config.LocalhostLogin(
+    token = webviz_config.LocalhostToken(
                 app.server,
                 ott={{'"' + ott + '"' if ott else None}},
                 cookie_token={{'"' + cookie_token + '"' if cookie_token else None}}
             ).one_time_token
 
-    {% if open_browser -%}
-    print(' \n\033[92m'
-          ' Webviz soon ready. The application will be opned in your default browser.\n'
-          ' Press CTRL+C in this terminal window to shut down the application.'
-          ' \033[0m\n')
+    webviz_config.LocalhostOpenBrowser({{port}}, token)
 
-    threading.Timer(5, lambda: webbrowser.open_new_tab(f'https://localhost:{{port}}?ott={token}')).start()
-    {%- endif %}
-
-    app.run_server(host='localhost', port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)
+    app.run_server(
+        host='localhost',
+        port={{port}},
+        ssl_context={{ssl_context}},
+        debug=False,
+        use_reloader=True,
+        dev_tools_hot_reload=True,
+        dev_tools_hot_reload_interval=1.0
+    )

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -106,7 +106,11 @@ if __name__ == '__main__':
     # This part is ignored when the webviz app is started
     # using Docker container and uwsgi (e.g. when hosted on Azure).
 
-    token = webviz_config.LocalhostLogin(app.server).one_time_token
+    token = webviz_config.LocalhostLogin(
+                app.server,
+                ott={{'"' + ott + '"' if ott else None}},
+                cookie_token={{'"' + cookie_token + '"' if cookie_token else None}}
+            ).one_time_token
 
     print(' \n\033[92m'
           ' You can go to\n'

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -120,7 +120,9 @@ if __name__ == '__main__':
         port={{port}},
         ssl_context={{ssl_context}},
         debug=False,
-        use_reloader=True,
+        use_reloader={{not portable}},
+        {% if not portable -%}
         dev_tools_hot_reload=True,
         dev_tools_hot_reload_interval=1.0
+        {% endif %}
     )

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -5,6 +5,7 @@
 import logging
 import logging.config
 import webbrowser
+import threading
 import os.path as path
 from pathlib import Path, PosixPath
 
@@ -112,13 +113,13 @@ if __name__ == '__main__':
                 cookie_token={{'"' + cookie_token + '"' if cookie_token else None}}
             ).one_time_token
 
+    {% if open_browser -%}
     print(' \n\033[92m'
-          ' Webviz ready. Opening the application in your default browser.\n'
+          ' Webviz soon ready. The application will be opned in your default browser.\n'
           ' Press CTRL+C in this terminal window to shut down the application.'
           ' \033[0m\n')
 
-    {% if open_browser -%}
-    webbrowser.open_new_tab(f'https://localhost:{{port}}?ott={token}\n')
+    threading.Timer(5, lambda: webbrowser.open_new_tab(f'https://localhost:{{port}}?ott={token}')).start()
     {%- endif %}
 
     app.run_server(host='localhost', port={{port}}, ssl_context={{ssl_context}}, debug=False, use_reloader=True, dev_tools_hot_reload=True, dev_tools_hot_reload_interval=1.0)


### PR DESCRIPTION
- [X] Use one-time-tokens instead (similar to how Jupyter notebook does it, but in addition do it on https). I.e. resolves #87.
- [X] Improve user experience when app reloads for same session after live changes to config file (use same token).
- [X] Resolves #86.
- [X] Resolves #95.
- [X] Add and update docstrings.