### PR TITLE
Remove depreciation warning for Markdown

### DIFF
--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -23,6 +23,7 @@ class _WebvizMarkdownExtension(Extension):
             priority = 50
         )
 
+
 class _MarkdownImageProcessor(ImageInlineProcessor):
     def __init__(self, image_link_re, md, base_path):
         self.base_path = base_path

--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -17,9 +17,11 @@ class _WebvizMarkdownExtension(Extension):
         super(_WebvizMarkdownExtension, self).__init__()
 
     def extendMarkdown(self, md):
-        md.inlinePatterns['image_link'] = \
-            _MarkdownImageProcessor(IMAGE_LINK_RE, md, self.base_path)
-
+        md.inlinePatterns.register(
+            item = _MarkdownImageProcessor(IMAGE_LINK_RE, md, self.base_path),
+            name = 'image_link',
+            priority = 50
+        )
 
 class _MarkdownImageProcessor(ImageInlineProcessor):
     def __init__(self, image_link_re, md, base_path):

--- a/webviz_config/containers/_markdown.py
+++ b/webviz_config/containers/_markdown.py
@@ -18,9 +18,9 @@ class _WebvizMarkdownExtension(Extension):
 
     def extendMarkdown(self, md):
         md.inlinePatterns.register(
-            item = _MarkdownImageProcessor(IMAGE_LINK_RE, md, self.base_path),
-            name = 'image_link',
-            priority = 50
+            item=_MarkdownImageProcessor(IMAGE_LINK_RE, md, self.base_path),
+            name='image_link',
+            priority=50
         )
 
 


### PR DESCRIPTION
Depreciated, see [these lines ](https://github.com/Python-Markdown/markdown/blob/cb9cdc86575dab7afd3296c030e338cea3fc936e/markdown/util.py#L387-L392)in the python-markdown code for reference..