### PR TITLE
abstractmethod → abstractproperty

### DIFF
--- a/webviz_config/containers/_container_class.py
+++ b/webviz_config/containers/_container_class.py
@@ -43,6 +43,7 @@ class WebvizContainer(abc.ABC):
     # All paths in the returned ASSETS list should be absolute.
     ASSETS = []
 
+    @property
     @abc.abstractmethod
     def layout(self):
         """This is the only required function of a Webviz Container.


### PR DESCRIPTION
As of [Python 3.3, `@abstractmethod` can correctly be combined with the `@property` decorator](https://docs.python.org/3.3/library/abc.html#abc.abstractproperty).

```python
class C(metaclass=ABCMeta):
    @property
    @abstractmethod
    def my_abstract_property(self):
        ...
```