### PR TITLE
Remove blinking text

### DIFF
--- a/webviz_config/utils/terminal_colors.py
+++ b/webviz_config/utils/terminal_colors.py
@@ -1,8 +1,8 @@
-BLUE = "\x1b[37;44m"
-GREEN = "\x1b[37;42m"
-PURPLE = "\x1b[37;45m"
 RED = "\x1b[37;41m"
-YELLOW = "\x1b[2;30;43m"
+GREEN = "\x1b[37;42m"
+YELLOW = "\x1b[37;43m"
+BLUE = "\x1b[37;44m"
+PURPLE = "\x1b[37;45m"
 
 BOLD = "\x1b[1m"
 END = "\x1b[0m"

--- a/webviz_config/utils/terminal_colors.py
+++ b/webviz_config/utils/terminal_colors.py
@@ -1,7 +1,7 @@
-BLUE = "\x1b[5;37;44m"
-GREEN = "\x1b[5;37;42m"
-PURPLE = "\x1b[0;37;45m"
-RED = "\x1b[5;37;41m"
+BLUE = "\x1b[37;44m"
+GREEN = "\x1b[37;42m"
+PURPLE = "\x1b[37;45m"
+RED = "\x1b[37;41m"
 YELLOW = "\x1b[2;30;43m"
 
 BOLD = "\x1b[1m"


### PR DESCRIPTION
Before this PR, the ANSI sequences included an unnecessary and flashy _blinking effect_ (note that some terminal emulators ignore blink codes, so this is not always apparent).