### PR TITLE
Extend CI to Python{3.7, 3.8}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ services:
 
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 matrix:
   fast_finish: true
@@ -43,6 +45,7 @@ deploy:
       secure: zWVmufs7SMXuV2BMukQnDxvNxTS7GWDLbcGmvEqN4js7oR1h8N4qo0z27kB/OqosLEq37G429BIAIZJAu/Xxja6LLHDQmw18zTlC3wMYxifiU9l0sUn/I7zeqMpLsQERXJIzYhneG4KMvmXxUHSlouOlLKWtQHiraTshvjlAz53Bg6tz6rfASF3kG9CvhEcSVOseG2uJe1N8cBIG2huHZEsJBjVZr/JVoD+tX0y9csEGvO/B1xLJVDMY5DvMmPPCwaEb+O4OUlGpxtfmHRKUvG6fehTZXyyBJVuR58WO2uThOYmSFiaavtvjbIpvJyb8SXM2OmikFGdavipLPtPVZ9qkPorBT9NNKGGRt+h0A/1CVYV4ALp6YmF4r9hWYihMGaJlNgM0lA8322LvwfIjGH6exuZ0/EQxJb5P031icv7ZV4s8zTQON5PJtBU+GxXqVOS2hK8sSuSmvRqpQXWkOrtqKyJ0bu7jAVpw+Xr9C8oWVZ6FTr13t+/ney7PQCCnUZk+F0j3W3bIogTLrG21r49hJYP2TtDGyFf3BUf2ulfMQ+WGwJdc3WjL2XTtgi61dTo9IJKp9pk2+RMjPJQrPNu0mEsJePHHclODIieSw+/nfOsj47Ng1Ku+ZkJq09OngdzzqtMENHtdYgB/qAl+cJxm1e61wzpMLo2iUbQjAiw=
     keep_history: true
     on:
+      python: "3.6"
       branch: master
       repo: equinor/webviz-config
 
@@ -51,5 +54,6 @@ deploy:
     password:
       secure: nPhoazwJZ2bOq8T2C9bMdzVS7mACdUkgwdmhEnsFrWT7Oh46h5ypuuaIl/Ir23n5OUYoZS+mg230hclD12McTafnH8MQnGpyooViuZy1oRWzbjjcdI5jq4poEmZokC0pS4ZM+lNeQ01eI4z3BMxwsYvvgZWVyBU+vVtwUSNrRrMnR9Vd3Wg7K17646/OvGsSoYJsN7G64Pm/rLmvphAebWYN/rwfZFz/bOPAhXJkgBmxZDZm2c4H04vCnftPhRSeL3nP7RsZQID/S1KoUuedN/E1inDg/PSAWXTWaRgbL5p6lHvbFC13Z26viRw7tD7BKo3irYxIsUup/v6rD1bwAZvaRGih1rQ5DCShOD/Yz70MpLmnDgiq2GMYWraROq/Uw+HieN+7mg2oPD7ChPeAWLBLmFw7sjZp8qwHq/3qSPARLZqRhAMOltiDtqv7llxv2w8jOcPI0hX7q1KdkWSrv7Nsf0g1wYN8G27+OM4OnDDh8q4R0EherpWQ4vSDN81d4jy8+YQcq8ALOS1k6A7XH5iP50sCArKyJzySs8IeMTT5m7/ddF/x8hnvTQxmdJMYaPAM0TSumdGFmGO0fash1I4NB8R5++ZY8185ELhSuiqz/4vZnA0Gi29yDVSIjOtjKCbPiaQRe0shue2+5zXpeH83MtS0SFD3EVgQ/yt4R58=
     on:
+      python: "3.6"
       tags: true
       repo: equinor/webviz-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ python:
   - "3.7"
   - "3.8"
 
-matrix:
+jobs:
   fast_finish: true
+  allow_failures:
+    - python: "3.8"
 
 before_install:
   - sudo apt-get -qq update

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/equinor/webviz-config/blob/master/LICENSE"><img src="https://img.shields.io/github/license/equinor/webviz-config.svg?color=dark-green"></a>
 <a href="https://travis-ci.org/equinor/webviz-config"><img src="https://travis-ci.org/equinor/webviz-config.svg?branch=master"></a>
 <a href="https://www.codacy.com/manual/webviz/webviz-config?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/webviz-config&amp;utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/1d7a659ea4784aa396ac1cb101c8e678"></a>
-<a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.6+-blue.svg"></a>
+<a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg"></a>
 <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 <br/>


### PR DESCRIPTION
Currently running only CI on Python `3.6`. Extend to `[3.6, 3.7, 3.8]`.

`3.8` is set to currently be allowed to fail, as one or more upstream dependencies are not yet available for Python 3.8. See [this `pyarrow` issue](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-6954?filter=allopenissues).