### PR TITLE
Use dash~=1.7. Remove hidden dash table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     },
     entry_points={"console_scripts": ["webviz=webviz_config.command_line:main"]},
     install_requires=[
-        "dash~=1.1",
+        "dash>=1.7",
         "bleach~=3.1",
         "cryptography~=2.4",
         "flask-caching~=1.4",
@@ -41,7 +41,7 @@ setup(
         "pandas~=0.24",
         "pyarrow~=0.11",
         "pyyaml~=5.1",
-        "webviz-core-components>=0.0.10",
+        "webviz-core-components>=0.0.12",
     ],
     tests_require=TESTS_REQUIRES,
     extras_require={"tests": TESTS_REQUIRES},

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     },
     entry_points={"console_scripts": ["webviz=webviz_config.command_line:main"]},
     install_requires=[
-        "dash>=1.7",
+        "dash~=1.7",
         "bleach~=3.1",
         "cryptography~=2.4",
         "flask-caching~=1.4",

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -107,12 +107,6 @@ else:
                 className="styledButton",
               {%- endif -%}
                 children=[
-                  {%- if loop.first -%}
-                    html.Div(
-                        id="dash-issue-#1010",
-                        style={"display":"none"}, 
-                        children=dash_table.DataTable()),
-                  {%- endif -%}
                   {% for content in page.content -%}
                   {%- if content is string -%}
                     dcc.Markdown(r"""{{ content }}""")

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -14,7 +14,6 @@ from pathlib import Path, PosixPath
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import dash_table
 from flask_talisman import Talisman
 import webviz_config
 from webviz_config.common_cache import CACHE


### PR DESCRIPTION
[Dash 1.7.0](https://github.com/plotly/dash/releases/tag/v1.7.0) includes the fix for `https://github.com/plotly/dash/pull/1027`.

It is no longer necessary to have a hidden dash_table in the initial rendered layout.

- Bump dash to 1.7
- Remove hidden table
- Also bump webviz-core-components