### PR TITLE
Support third-party containers checking shared_settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,6 +381,50 @@ different input also have different string output from `__repr__`.
 `@CACHE.memoize`, following the same order as in the example above usually gives 
 best performance.
 
+### Common settings
+
+If you create multiple containers that have some settings in common, you can
+_"subscribe"_ to keys in the dictionary `shared_settings`, defined by the user
+in the configuration file. E.g. assume that the user enters something like this at
+top level in the configuration file:
+```yaml
+shared_settings:
+  some_key:
+    some_settings1: ...
+    some_settings2: ...
+```
+
+You can then early in the application loading process get to run a function checking,
+and potentially transforming, the settings. The latter is useful e.g. if you want to
+convert some string, representing a path relative to the configuration file, to an
+absolute path.
+
+The way you subscribe to a shared setting is that you in your Python package add
+something like
+```python
+import webviz_config
+
+@webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.subscribe("some_key")
+def subscribe(some_key, config_folder):
+    # The input argument some_key given to this function is equal to
+    # shared_settings["some_key"] provided by the user from the configuration file.
+
+    # Do some checks on the settings?
+
+    # Do some transformation on the settings?
+
+    return some_key # The returned value here is put back into shared_settings["some_key"]
+```
+
+The (optionally transformed) `shared_settings` are accessible to containers through
+the `app` instance (see [callbacks](#callbacks)). E.g., in this case the wanted settings
+are found as `app.webviz_settings["shared_settings"]["some_key"]`.
+
+Stating the second input argument `config_folder` in the function signature is not
+necessary, however if you do you will get a
+[`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
+instance representing the absolute path to the configuration file that was used.
+
 ### Custom ad-hoc containers
 
 It is possible to create custom containers which still can be included through

--- a/webviz_config/__init__.py
+++ b/webviz_config/__init__.py
@@ -6,6 +6,7 @@ from ._localhost_certificate import LocalhostCertificate
 from ._is_reload_process import is_reload_process
 from ._container_abc import WebvizContainerABC
 from ._theme_class import WebvizConfigTheme
+from ._shared_settings_subscriptions import SHARED_SETTINGS_SUBSCRIPTIONS
 
 try:
     __version__ = get_distribution(__name__).version

--- a/webviz_config/_shared_settings_subscriptions.py
+++ b/webviz_config/_shared_settings_subscriptions.py
@@ -1,0 +1,46 @@
+import copy
+import inspect
+import pathlib
+
+
+class SharedSettingsSubscriptions:
+    """The user can configure common settings, shared between different cointainers,
+    under a key called `shared_settings` in the configuration file. Since it originates
+    from a native yaml file, the content is dictionaries/strings/ints.
+
+    Third-party container packages  might want to check early if the `shared_settings`
+    they use are reasonable, and/or do some transformations on them.
+    """
+
+    def __init__(self):
+        self._subscriptions = []
+
+    def subscribe(self, key):
+        """This is the decorator, which third-party container packages will use.
+        """
+
+        def register(function):
+            self._subscriptions.append({"key": key, "function": function})
+            return function
+
+        return register
+
+    def transformed_settings(self, shared_settings, config_folder):
+        """Called from the app template, which returns the `shared_settings` after
+        all third-party package subscriptions has done their (optional) transfomrations.
+        """
+        shared_settings = copy.deepcopy(shared_settings)
+
+        for subscription in self._subscriptions:
+            key, function = subscription["key"], subscription["function"]
+            requires_config_folder = len(inspect.getfullargspec(function).args) > 1
+            shared_settings[key] = (
+                function(shared_settings.get(key), pathlib.Path(config_folder))
+                if requires_config_folder
+                else function(shared_settings.get(key))
+            )
+
+        return shared_settings
+
+
+SHARED_SETTINGS_SUBSCRIPTIONS = SharedSettingsSubscriptions()

--- a/webviz_config/_shared_settings_subscriptions.py
+++ b/webviz_config/_shared_settings_subscriptions.py
@@ -6,9 +6,9 @@ import pathlib
 class SharedSettingsSubscriptions:
     """The user can configure common settings, shared between different cointainers,
     under a key called `shared_settings` in the configuration file. Since it originates
-    from a native yaml file, the content is dictionaries/strings/ints.
+    from a native yaml file, the content is dictionaries/strings/ints/floats/dates.
 
-    Third-party container packages  might want to check early if the `shared_settings`
+    Third-party container packages might want to check early if the `shared_settings`
     they use are reasonable, and/or do some transformations on them.
     """
 
@@ -26,8 +26,9 @@ class SharedSettingsSubscriptions:
         return register
 
     def transformed_settings(self, shared_settings, config_folder):
-        """Called from the app template, which returns the `shared_settings` after
-        all third-party package subscriptions has done their (optional) transfomrations.
+        """Called from the app template, which returns the `shared_settings`
+        after all third-party package subscriptions have done their
+        (optional) transfomrations.
         """
         shared_settings = copy.deepcopy(shared_settings)
 

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -1,7 +1,10 @@
 import os
 import getpass
 import datetime
+import pathlib
+
 import jinja2
+
 from .themes import installed_themes
 from ._config_parser import ConfigParser
 
@@ -11,7 +14,9 @@ def write_script(args, build_directory, template_filename, output_filename):
     config_parser = ConfigParser(args.yaml_file)
     configuration = config_parser.configuration
 
+    configuration["shared_settings"] = config_parser.shared_settings
     configuration["portable"] = args.portable is not None
+    configuration["config_folder"] = repr(pathlib.Path(args.yaml_file).resolve().parent)
 
     theme = installed_themes[args.theme]
     configuration["csp"] = theme.csp

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -5,10 +5,11 @@ import os.path as path
 from pathlib import Path, PosixPath
 
 import dash
+
+import webviz_config
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
-
 
 
 {% for module in _imports %}
@@ -23,6 +24,7 @@ app = dash.Dash()
 app.config.suppress_callback_exceptions = True
 
 app.webviz_settings = {
+    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings({{ shared_settings }}, {{ config_folder }}),
     "plotly_layout": {{ plotly_layout }},
 }
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -24,7 +24,9 @@ app = dash.Dash()
 app.config.suppress_callback_exceptions = True
 
 app.webviz_settings = {
-    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings({{ shared_settings }}, {{ config_folder }}),
+    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
+        {{ shared_settings }}, {{ config_folder }}
+    ),
     "plotly_layout": {{ plotly_layout }},
 }
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -59,7 +59,9 @@ app.title = "{{ title }}"
 app.config.suppress_callback_exceptions = True
 
 app.webviz_settings = {
-    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings({{ shared_settings }}, {{ config_folder }}),
+    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
+        {{ shared_settings }}, {{ config_folder }}
+    ),
     "portable": {{ portable }},
     "plotly_layout": {{ plotly_layout }},
 }

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -59,6 +59,7 @@ app.title = "{{ title }}"
 app.config.suppress_callback_exceptions = True
 
 app.webviz_settings = {
+    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings({{ shared_settings }}, {{ config_folder }}),
     "portable": {{ portable }},
     "plotly_layout": {{ plotly_layout }},
 }


### PR DESCRIPTION
Resolves #160.

Third-party containers can, in order to get rid of depreciation warning introduced here, do the following change:

Go from e.g.
```python
def __init__(self, app, container_settings, ...):
    something = container_settings["something"]
    ...
```
to
```python
def __init__(self, app, ...):
    something = app.webviz_settings["shared_settings"]["something"]
    ...
```