### PR TITLE
Support mutable objects in webviz-store

### DIFF
--- a/webviz_config/webviz_store.py
+++ b/webviz_config/webviz_store.py
@@ -63,9 +63,13 @@ class WebvizStorage:
         for func, arglist in functionarguments:
             undec_func = WebvizStorage._undecorate(func)
             for args in arglist:
-                argtuples = WebvizStorage._dict_to_tuples(WebvizStorage.complete_kwargs(func, args))
+                argtuples = WebvizStorage._dict_to_tuples(
+                    WebvizStorage.complete_kwargs(func, args)
+                )
                 if repr(argtuples) not in self.storage_function_argvalues[undec_func]:
-                    self.storage_function_argvalues[undec_func][repr(argtuples)] = argtuples
+                    self.storage_function_argvalues[undec_func][
+                        repr(argtuples)
+                    ] = argtuples
 
     def _unique_path(self, func, argtuples):
         """Encodes the argumenttuples as bytes, and then does a sha256 on that.


### PR DESCRIPTION
Closes #93. Closes #166.

After this PR, all argument types should work in `webviz-store` (as long as they have a well behaving `__repr__` implementation). This is the same "limitation" as [`flask-caching`](https://github.com/sh4nks/flask-caching) has.