### PR TITLE
Support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ python:
   - "3.7"
   - "3.8"
 
-jobs:
-  fast_finish: true
-  allow_failures:
-    - python: "3.8"
-
 before_install:
   - sudo apt-get -qq update
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/equinor/webviz-config/blob/master/LICENSE"><img src="https://img.shields.io/github/license/equinor/webviz-config.svg?color=dark-green"></a>
 <a href="https://travis-ci.org/equinor/webviz-config"><img src="https://travis-ci.org/equinor/webviz-config.svg?branch=master"></a>
 <a href="https://www.codacy.com/manual/webviz/webviz-config?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/webviz-config&amp;utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/1d7a659ea4784aa396ac1cb101c8e678"></a>
-<a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg"></a>
+<a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.6%20|%203.7%20|%203.8-blue.svg"></a>
 <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 <br/>

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "jinja2~=2.10",
         "markdown~=3.0",
         "pandas~=0.24",
-        "pyarrow~=0.11",
+        "pyarrow~=0.16",
         "pyyaml~=5.1",
         "webviz-core-components>=0.0.16",
     ],


### PR DESCRIPTION
With release `0.16` of `pyarrow` from Apache, all dependencies now support Python 3.8. I.e. we can add 3.8 to the list of supported Python version, and at the same time require it to succeed in CI.