### PR TITLE
CSP change while waiting for upstream issue in plotly.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This Python package, `webviz-config`, is the core plugin framework. For a real e
 - **You know [Python](https://www.python.org/)**, and want to create generic or specialized dashboards you or other users can reuse by simply asking for it in the Webviz configuration file. This can be done without knowing JavaScript (see also [Dash](https://plot.ly/dash/) for more information).
 - **You know [React](https://reactjs.org/)**, and want to create highly specialized visualization which Python or pure config-file users can reuse.
 
-*Webviz* will create web applications with very :lock: strict security headers and CSP settings, giving an rating of **A+** on e.g. [Mozilla observatory](https://observatory.mozilla.org/). It also facilitates a :whale: Docker setup, where the Python code can be ran completely unpriviliged in a sandbox (both with respect to file system access and network communication).
+*Webviz* will create web applications with very :lock: strict security headers and CSP settings, giving an rating of **A+** on e.g. [Mozilla observatory](https://observatory.mozilla.org/) (note that generated applications are temporarily not getting A+ due to [this `plotly.js` issue](https://github.com/plotly/plotly.js/issues/897)). It also facilitates a :whale: Docker setup, where the Python code can be ran completely unpriviliged in a sandbox (both with respect to file system access and network communication).
 
 Example configuration file and information about the standard plugins can be seen in [the documentation](https://equinor.github.io/webviz-config/).
 

--- a/webviz_config/_theme_class.py
+++ b/webviz_config/_theme_class.py
@@ -17,14 +17,15 @@ class WebvizConfigTheme:
             "style-src": ["'self'", "'unsafe-inline'"],  # [1]
             "script-src": [
                 "'self'",
-                "'sha256-jZlsGVOhUAIcH+4PVs7QuGZkthRMgvT2n0ilH6/zTM0='",
-            ],  # [2]
+                "'unsafe-eval'",  # [2]
+                "'sha256-jZlsGVOhUAIcH+4PVs7QuGZkthRMgvT2n0ilH6/zTM0='",  # [3]
+            ],
             "img-src": ["'self'", "data:"],
             "navigate-to": "'self'",
             "base-uri": "'self'",
             "form-action": "'self'",
-            "frame-ancestors": "'self'",  # [3]
-            "frame-src": "'self'",  # [3]
+            "frame-ancestors": "'self'",  # [4]
+            "frame-src": "'self'",  # [4]
             "object-src": "'self'",
             "plugin-types": "application/pdf",
         }
@@ -33,8 +34,10 @@ class WebvizConfigTheme:
         These are the current exceptions to the most strict CSP setup:
             [1] unsafe-inline for style still needed by plotly
                 (https://github.com/plotly/plotly.js/issues/2355)
-            [2] https://github.com/plotly/dash/issues/630
-            [3] We use 'self' instead of 'none' due to what looks like a Chromium bug,
+            [2] unsafe-eval still needed for plotly.js bundle
+                (https://github.com/plotly/plotly.js/issues/897)
+            [3] https://github.com/plotly/dash/issues/630
+            [4] We use 'self' instead of 'none' due to what looks like a Chromium bug,
                 where e.g. pdf's included using <embed> is not rendered. Might be
                 related to https://bugs.chromium.org/p/chromium/issues/detail?id=1002610
         """


### PR DESCRIPTION
There are use cases for using the full `plotly.js` plotting library (not only the cartesian `plotly.js` bundle like we currently use) - e.g. for visualizing parallel coordinates. However due to the open upstream `plotly.js` issue referenced in this PR, it requires `unsafe-eval` to be added to `script-src` while waiting for the upstream fix in `plotly.js`.