### PR TITLE
Load css and js assets automatically in non-portable mode

### DIFF
--- a/examples/demo_portable.yaml
+++ b/examples/demo_portable.yaml
@@ -11,3 +11,5 @@ pages:
         some_number: 42
     - ExampleAssets:
         picture_path: ./example_banner.png
+        css_path: ./example_stylesheet.css
+        js_path: ./example_javascript.js

--- a/examples/example_javascript.js
+++ b/examples/example_javascript.js
@@ -1,0 +1,1 @@
+alert("This loaded JavaScript file comes from a plugin.");

--- a/examples/example_stylesheet.css
+++ b/examples/example_stylesheet.css
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/webviz_config/plugins/_example_assets.py
+++ b/webviz_config/plugins/_example_assets.py
@@ -7,10 +7,16 @@ from ..webviz_assets import WEBVIZ_ASSETS
 
 
 class ExampleAssets(WebvizPluginABC):
-    def __init__(self, picture_path: Path):
+    def __init__(self, picture_path: Path, css_path: Path = None, js_path: Path = None):
         super().__init__()
 
         self.asset_url = WEBVIZ_ASSETS.add(picture_path)
+
+        if css_path is not None:
+            WEBVIZ_ASSETS.add(css_path)
+
+        if js_path is not None:
+            WEBVIZ_ASSETS.add(js_path)
 
     @property
     def layout(self) -> html.Img:

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -63,7 +63,6 @@ WEBVIZ_STORAGE.storage_folder = path.join(
 )
 
 WEBVIZ_ASSETS.portable = {{ portable }}
-{{ "WEBVIZ_ASSETS.register_app(app)" if not portable else ""}}
 
 if {{ not portable }} and not webviz_config.is_reload_process():
     # When Dash/Flask is started on localhost with hot module reload activated,
@@ -105,6 +104,8 @@ else:
             )  {{- "" if loop.last else "," -}}
         {% endfor %}],
     )
+
+{{ "WEBVIZ_ASSETS.directly_host_assets(app)" if not portable else ""}}
 
 if __name__ == "__main__":
     # This part is ignored when the webviz app is started


### PR DESCRIPTION
Resolves #207.

This PR makes the `WebvizAssets` behavior consistent between non-portable and portable runs, in the sense that plugin added JavaScript and CSS assets are loaded automatically by Dash in the browser (it already did for portable runs, but not for non-portable before this PR).

- [X] Load CSS and JS assets automatically also in non-portable mode.
- [X] ~Add CI test for this non-portable only feature.~ Moved to #203.