### PR TITLE
Limit dash version to 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "bleach>=3.1",
         "cryptography>=2.4",
-        "dash>=1.7",
+        "dash>=1.7,<1.11",
         "flask-caching>=1.4",
         "flask-talisman>=0.6",
         "jinja2>=2.10",


### PR DESCRIPTION
Necessary due to https://github.com/plotly/dash/issues/1200 and problems with webviz-subsurface.