### PR TITLE
Use urls instead of tabs for main layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - YYYY-MM-DD
+
+### Changed
+
+- [#230](https://github.com/equinor/webviz-config/pull/230) - Instead of using
+`dcc.Tabs` to give the impression of a "multipage app", webviz now uses `dcc.Link` and
+`dcc.Location`. This has two main advantages: Big applications can have significantly
+faster loading time, as only callbacks on selected "page" fire initially. In addition,
+the user can navigate with forward/backward buttons in browser, as well as getting
+an URL they can share with others in order to point them to the correct "page". Plugin
+authors should check that persistence is set to `session` on Dash components they use
+if they want user selections to remain across "page" changes. In order to get more
+easily typed URLs, runtime generated page IDs now use `-` instead of `_` for spaces.
+
 ## [0.1.4] - 2020-09-24
 
 ### Added

--- a/tests/test_portable.py
+++ b/tests/test_portable.py
@@ -25,12 +25,11 @@ def test_portable(dash_duo, tmp_path):
     # Start and test app
     dash_duo.start_server(app)
     for page in [
-        "markdown_example",
-        "table_example",
-        "pdf_example",
-        "syntax_highlighting_example",
-        "plot_a_table",
-        "last_page",
+        "markdown-example",
+        "table-example",
+        "pdf-example",
+        "syntax-highlighting-example",
+        "plot-a-table",
     ]:
         dash_duo.wait_for_element(f"#{page}").click()
     assert dash_duo.get_logs() == [], "browser console should contain no error"

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -195,10 +195,10 @@ class ConfigParser:
 
     def _generate_page_id(self, title: str) -> str:
         """From the user given title, this function provides a unique
-        human readable page id, not already present in self._page_ids
+        human readable page id, not already present in `self._page_ids`.
         """
 
-        base_id = re.sub("[^-a-z0-9_]+", "", title.lower().replace(" ", "_"))
+        base_id = re.sub("[^-a-z0-9_]+", "", title.lower().replace(" ", "-"))
 
         page_id = base_id
 

--- a/webviz_config/static/assets/webviz_layout.css
+++ b/webviz_config/static/assets/webviz_layout.css
@@ -1,4 +1,4 @@
-div.styledLogo.tab {
+.styledLogo {
     border: none;
     background: transparent;
     outline: none;
@@ -8,7 +8,7 @@ div.styledLogo.tab {
     padding: 20px 30px;
 }
 
-div.styledButton.tab {
+.styledButton {
     border: none;
     background: transparent;
     outline: none;
@@ -26,17 +26,17 @@ div.styledButton.tab {
     border-bottom: 1px solid white;
 }
 
-div.styledButton.tab:hover {
+.styledButton:hover {
     color: var(--menuLinkHoverColor);
     background-color: var(--menuLinkBackgroundHover);
 }
 
-div.selectedButton.tab--selected {
+.selectedButton--selected {
     color: var(--menuLinkColorSelected);
     background-color: var(--menuLinkBackgroundSelected);
 }
 
-div.pageWrapper.tab-content {
+.pageWrapper {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -44,13 +44,29 @@ div.pageWrapper.tab-content {
 }
 
 .layoutWrapper {
+    display: flex;
+    flex-direction: row;
     width: 100%;
 }
-
-.wrapper {
+.sideWrapper {
     display: flex;
+    flex: 1;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    height: 100vh;
+    min-width: 30rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--menuBackground) var(--menuBackground); /* thumb and track color */    
+}
+
+.pageContent {
+    display: flex;
+    flex: 8;
+    flex-direction: column;
     height: 100%;
     width: 100%;
+    padding: 15px;
 }
 
 .logoWrapper {
@@ -60,55 +76,47 @@ div.pageWrapper.tab-content {
     align-items: center;
 }
 
-.sideBar {
-    overflow-x: hidden;
-    overflow-y: scroll;
-    height: 100vh;
-    min-width: 30rem;
-    scrollbar-width: thin;
-    scrollbar-color: var(--menuBackground) var(--menuBackground); /* thumb and track color */
-}
-
 @media (min-width: 800px) {
-    .sideBar {
+    .sideWrapper {
         width: 30rem;
     }
 }
 
-.sideBar:hover {
+.sideWrapper:hover {
     scrollbar-color: var(--menuLinkColor) var(--menuBackground); /* thumb and track color */
 }
 
-.sideBar::-webkit-scrollbar
+.sideWrapper::-webkit-scrollbar
 {
 	width: 3px;
 	background-color:var(--menuBackground);
 }
 
-.sideBar::-webkit-scrollbar-track
+.sideWrapper::-webkit-scrollbar-track
 {
 	-webkit-box-shadow: inset 0 0 3px var(--menuBackground);
 	background-color: var(--menuBackground);
 }
 
-.sideBar:hover::-webkit-scrollbar-track
+.sideWrapper:hover::-webkit-scrollbar-track
 {
     -webkit-box-shadow: inset 0 0 3px var(--menuLinkBackgroundHover);
-    
 	background-color: var(--menuBackground);
 }
 
-.sideBar::-webkit-scrollbar-thumb
+.sideWrapper::-webkit-scrollbar-thumb
 {
 	background-color: var(--menuBackground);
 }
 
-.sideBar:hover::-webkit-scrollbar-thumb
+.sideWrapper:hover::-webkit-scrollbar-thumb
 {
 	background-color: var(--menuLinkColor);
 }
 
-
-/* Needed to override border for the last tab */
-#last_page {border: none!important;} /* csslint allow: known-properties, important */
-#logo {padding:50px!important; border: none!important;max-width: 100%; height:auto;} /* csslint allow: known-properties, important */
+#logo {
+    padding: 50px;
+    border: none;
+    max-width: 100%;
+    height: auto;
+}

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -76,40 +76,58 @@ if {{ not portable }} and not webviz_config.is_reload_process():
     # from the child/restart/reload process.
     app.layout = html.Div()
 else:
-    app.layout = dcc.Tabs(
-        parent_className="layoutWrapper",
-        content_className="pageWrapper",
-        className="sideBar",
-        vertical=True,
-        children=[
-          {% for page in pages %}
-            dcc.Tab(
-              {%- if loop.first -%}
-                id="logo",
-                className="styledLogo",
-              {%- else -%}
-                {%- if loop.last -%}
-                id="last_page",
-                {%- else -%}
-                id="{{page.id}}",
-                {%- endif -%}
-                label="{{page.title}}",
-                selected_className="selectedButton",
-                className="styledButton",
-              {%- endif -%}
-                children=[
-                  {% for content in page.content -%}
-                  {%- if content is string -%}
-                    dcc.Markdown(r"""{{ content }}""")
-                  {%- else -%}
-                    {{ content._call_signature[0] }}.{{ content._call_signature[1] }}
-                  {%- endif -%}
-                  {{- "" if loop.last else ","}}
-                  {% endfor -%}
-                ],
-            )  {{- "" if loop.last else "," -}}
-        {% endfor %}],
-    )
+    page_content = {}
+    {% for page in pages %}
+    page_content["{{page.id}}"] = [
+       {% for content in page.content -%}
+       {%- if content is string -%}
+         dcc.Markdown(r"""{{ content }}""")
+       {%- else -%}
+         {{ content._call_signature[0] }}.{{ content._call_signature[1] }}
+       {%- endif -%}
+       {{- "" if loop.last else ","}}
+       {% endfor -%}
+    ]
+    {% endfor %}
+    app.layout = html.Div(
+        className="layoutWrapper", 
+        children=[html.Div(
+            children=[dcc.Location(
+                id='url', refresh=True),
+        html.Div(
+            className="sideWrapper",
+            children=[
+            {% for page in pages %}
+                dcc.Link(
+                    {%- if loop.first -%}
+                    "",
+                    id="logo",
+                    className="styledLogo",
+                    href="/",
+                    {%- else -%}
+                    "{{page.title}}",
+                    # We will create a webviz-core-components
+                    # component instead of styling dcc.Link's,
+                    # then we can more easily change className to
+                    # selectedButton for current page.
+                    className="styledButton",
+                    id="{{page.id}}",
+                    href="/{{page.id}}",
+                    {%- endif -%}
+                    )
+                 {{- "" if loop.last else "," -}}
+            {% endfor %}
+            ])]),
+        html.Div(className="pageContent", id="page-content")])
+
+
+@app.callback(dash.dependencies.Output("page-content", "children"),
+              dash.dependencies.Input("url", "pathname"))
+def update_page(pathname):
+    pathname = pathname.replace("/", "")
+    if not pathname:
+        pathname = "front-page"
+    return page_content.get(pathname, "Oooppss... Page not found.")
 
 {{ "WEBVIZ_ASSETS.directly_host_assets(app)" if not portable else ""}}
 


### PR DESCRIPTION
An attempt to replace current tab based page navigation with [dcc.Location](https://dash.plotly.com/urls).

- Components will require persistence as they are reloaded on page switching
- Initial load of app should be must faster, but page switching might be somewhat slower


