### PR TITLE
Improve selectors in TablePlotter

### DIFF
--- a/webviz_config/plugins/_table_plotter.py
+++ b/webviz_config/plugins/_table_plotter.py
@@ -26,6 +26,7 @@ If feature is requested, the data could also come from a database.
 * `csv_file`: Path to the csv file containing the tabular data. Either absolute
               path or relative to the configuration file.
 * `plot_options`: A dictionary of plot options to initialize the plot with
+* `filter_cols`: Dataframe columns that can be used to filter data
 * `lock`: If `True`, only the plot is shown, all dropdowns for changing
           plot options are hidden.
 """
@@ -72,15 +73,7 @@ If feature is requested, the data could also come from a database.
         """A list of available plots and their options"""
         return {
             "scatter": ["x", "y", "size", "color", "facet_col"],
-            "histogram": [
-                "x",
-                "y",
-                "color",
-                "facet_col",
-                "barmode",
-                "barnorm",
-                "histnorm",
-            ],
+            "histogram": ["x", "color", "facet_col", "barmode", "barnorm", "histnorm",],
             "bar": ["x", "y", "color", "facet_col"],
             "scatter_3d": ["x", "y", "z", "size", "color"],
             "line": ["x", "y", "color", "line_group", "facet_col"],
@@ -102,46 +95,55 @@ If feature is requested, the data could also come from a database.
                     "options": self.columns,
                     "value": self.plot_options.get("x", self.columns[0]),
                     "multi": False,
+                    "clearable": False,
                 },
                 "y": {
                     "options": self.columns,
                     "value": self.plot_options.get("y", self.columns[0]),
                     "multi": False,
+                    "clearable": False,
                 },
                 "z": {
                     "options": self.columns,
                     "value": self.plot_options.get("z", self.columns[0]),
                     "multi": False,
+                    "clearable": False,
                 },
                 "size": {
                     "options": self.numeric_columns,
                     "value": self.plot_options.get("size", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "color": {
                     "options": self.columns,
                     "value": self.plot_options.get("color", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "facet_col": {
                     "options": self.columns,
                     "value": self.plot_options.get("facet_col", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "line_group": {
                     "options": self.columns,
                     "value": self.plot_options.get("line_group", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "barmode": {
                     "options": ["stack", "group", "overlay", "relative"],
                     "value": self.plot_options.get("barmode", "stack"),
                     "multi": False,
+                    "clearable": True,
                 },
                 "barnorm": {
                     "options": ["fraction", "percent"],
                     "value": self.plot_options.get("barnorm", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "histnorm": {
                     "options": [
@@ -152,16 +154,19 @@ If feature is requested, the data could also come from a database.
                     ],
                     "value": self.plot_options.get("histnorm", None),
                     "multi": False,
+                    "clearable": True,
                 },
                 "trendline": {
                     "options": self.numeric_columns,
                     "value": None,
                     "multi": False,
+                    "clearable": True,
                 },
                 "dimensions": {
                     "options": self.columns,
                     "value": self.plot_options.get("dimensions", self.columns),
                     "multi": True,
+                    "clearable": True,
                 },
             }
         )
@@ -210,13 +215,13 @@ If feature is requested, the data could also come from a database.
                                 open=True,
                                 children=[
                                     html.Summary(col.lower().capitalize()),
-                                    dcc.Dropdown(
+                                    wcc.Select(
                                         id=self.uuid(f"filter-{col}"),
                                         options=[
                                             {"label": i, "value": i} for i in elements
                                         ],
                                         value=elements,
-                                        multi=True,
+                                        size=min(15, len(elements)),
                                     ),
                                 ],
                             )
@@ -255,7 +260,7 @@ If feature is requested, the data could also come from a database.
                         html.P(key),
                         dcc.Dropdown(
                             id=self.uuid(f"dropdown-{key}"),
-                            clearable=False,
+                            clearable=arg["clearable"],
                             options=[{"label": i, "value": i} for i in arg["options"]],
                             value=arg["value"],
                             multi=arg["multi"],

--- a/webviz_config/themes/default_assets/default_theme.css
+++ b/webviz_config/themes/default_assets/default_theme.css
@@ -363,60 +363,6 @@ a:active {
   border-color: var(--menuLinkBackgroundHover);
 }
 
-/* Forms
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
-input[type=email], input[type=number], input[type=search], input[type=text], input[type=tel], input[type=url], input[type=password], textarea, select {
-  height: 38px;
-  padding: 6px 10px;
-  /* The 6px vertically centers text on FF, ignored by Webkit */
-  background-color: #fff;
-  border: 1px solid #D1D1D1;
-  border-radius: 4px;
-  box-shadow: none;
-  box-sizing: border-box;
-  font-family: inherit;
-  font-size: inherit;
-  /*https://stackoverflow.com/questions/6080413/why-doesnt-input-inherit-the-font-from-body*/
-}
-
-/* Removes awkward default styles on some inputs for iOS */
-input[type=email], input[type=number], input[type=search], input[type=text], input[type=tel], input[type=url], input[type=password], textarea {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
-textarea {
-  min-height: 65px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-input[type=email]:focus, input[type=number]:focus, input[type=search]:focus, input[type=text]:focus, input[type=tel]:focus, input[type=url]:focus, input[type=password]:focus, textarea:focus, select:focus {
-  border: 1px solid var(--menuLinkBackgroundHover);
-  outline: 0;
-}
-
-label, legend {
-  display: block;
-  margin-bottom: 0px;
-}
-
-fieldset {
-  padding: 0;
-  border-width: 0;
-}
-
-input[type=checkbox], input[type=radio] {
-  display: inline;
-}
-
-label > .label-body {
-  display: inline-block;
-  margin-left: 0.5rem;
-  font-weight: normal;
-}
-
 /* Lists
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 ul {


### PR DESCRIPTION
Some minor fixes for TablePlotter:

- Use wcc.select for filters
- Make optional selectors (e.g. color, size) clearable
- Remove `y` variable from histogram

Also removed some css from default theme for wcc.select to work properly.