### PR TITLE
Keep stack frames from Dash and Flask internals

### DIFF
--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -127,6 +127,7 @@ if __name__ == "__main__":
         ssl_context=webviz_config.certificate.LocalhostCertificate().ssl_context,
         debug=False,
         use_reloader={{not portable}},
+        dev_tools_prune_errors=False,
       {% if not portable -%}
         dev_tools_hot_reload=True,
         dev_tools_hot_reload_interval=1.0,


### PR DESCRIPTION
Dash by default prunes errors (omitting stack frames from Dash and Flask internals). Sometimes, user made plugins trigger errors only in Dash/Flask layer, resulting in _no errors/tracebacks_ printed to console, making debug difficult.

This PR turns off Dash's default error pruning.