### PR TITLE
Skip python==3.8 and pandas<1.0 combination in CI

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -22,6 +22,10 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8']
         pandas-version: ['0.24.2', '1.*']  # Necessary as long as RHEL6 is used internally
+        exclude:
+          # Skip Python 3.8 and Pandas 0.24.2 combination due to missing 3.8 wheel for that specific pandas version
+          - python-version: '3.8'
+            pandas-version: '0.24.2'
 
     steps:
       - name: 📖 Checkout commit locally


### PR DESCRIPTION
We can soon stop supporting `pandas==0.24.2`, which is the latest `pandas` version to support RHEL6. But for a few more months, we need to support it (but we will safely ignore the combination `python==3.8` and `pandas==0.24.2` in CI).