### PR TITLE
Allow skipping code in init function during portable build

### DIFF
--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -14,7 +14,14 @@ from . import WebvizPluginABC
 from .utils import terminal_colors
 
 warnings.simplefilter("default", DeprecationWarning)
-SPECIAL_ARGS = ["self", "app", "container_settings", "_call_signature", "_imports"]
+SPECIAL_ARGS = [
+    "self",
+    "app",
+    "container_settings",
+    "_call_signature",
+    "_imports",
+    "_skip_portable_build",
+]
 
 
 def _get_webviz_plugins(module: types.ModuleType) -> list:
@@ -145,9 +152,15 @@ def _call_signature(
             DeprecationWarning,
         )
 
+    special_args_portable = special_args
+    if "_skip_portable_build" in argspec.args:
+        special_args += "_skip_portable_build=False, "
+        special_args_portable += "_skip_portable_build=True, "
+
     return (
         f"{module_name}.{plugin_name}({special_args}**{kwargs})",
         f"plugin_layout(contact_person={contact_person})",
+        f"{module_name}.{plugin_name}({special_args_portable}**{kwargs})",
     )
 
 

--- a/webviz_config/plugins/_example_portable.py
+++ b/webviz_config/plugins/_example_portable.py
@@ -8,11 +8,15 @@ from ..common_cache import CACHE
 
 
 class ExamplePortable(WebvizPluginABC):
-    def __init__(self, some_number: int):
+    def __init__(self, some_number: int, _skip_portable_build: bool = False):
         super().__init__()
 
         self.some_number = some_number
         self.some_string = "a"
+        if not _skip_portable_build:
+            self.output_string = str(
+                input_data_function(self.some_string, some_number=self.some_number)
+            )
 
     def add_webvizstore(self) -> List[tuple]:
         return [
@@ -24,7 +28,7 @@ class ExamplePortable(WebvizPluginABC):
 
     @property
     def layout(self) -> str:
-        return str(input_data_function(self.some_string, some_number=self.some_number))
+        return self.output_string
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -52,7 +52,7 @@ plugins = []
 {% for page in pages %}
 {% for content in page.content %}
 {% if content is not string %}
-plugins.append({{ content._call_signature[0] }})
+plugins.append({{ content._call_signature[2] }})
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Resolves #249 

This is a suggestion, might be a neater way to do this, but works at least. Plugin writer can define an (optional) input `_skip_portable_build` (can of course switch this to something else), a boolean that can be used to skip parts of the `__init__` function during `copy_data.py` when building portables. Modified the `ExamplePortable`. This should preferably be defaulted to False to keep backwards compatibility (otherwise old portable apps have to be rebuilt).
