### PR TITLE
More robust GitHub action tag name

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set setuptools_scm version
         if: github.event_name == 'release'
         # Need to instruct setuptools_scm to use the GitHub provided tag, despite local git changes (due to build step)
-        run: echo '::set-env name=SETUPTOOLS_SCM_PRETEND_VERSION::${GITHUB_REF//refs\/tags\//}'
+        run: echo '::set-env name=SETUPTOOLS_SCM_PRETEND_VERSION::${{ github.event.release.tag_name }}'
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1


### PR DESCRIPTION
Suddenly the existing way of getting `git` tag variable out of GitHub action workflow has started failing. The recommended practice appears to recently been changed, at the same time providing a cleaner way of getting the tag variable. Changing accordingly.