### PR TITLE
Mark argparse subparser as required

### DIFF
--- a/webviz_config/command_line.py
+++ b/webviz_config/command_line.py
@@ -14,11 +14,14 @@ def main() -> None:
     )
 
     subparsers = parser.add_subparsers(
-        help="The options available. "
-        'Type e.g. "webviz build --help" '
-        "to get help on that particular "
-        "option."
+        metavar="SUBCOMMAND",
+        help="Below are the available subcommands listed. "
+        "Type e.g. 'webviz build --help' "
+        "to get help on one particular "
+        "subcommand.",
     )
+    # When dropping Python 3.6 support, 'required' can be given as an argument to add_subparsers.
+    subparsers.required = True
 
     # Add "build" argument parser:
 


### PR DESCRIPTION
Resolves #254.

After this change, running `webviz` without any arguments returns (Python 3.6.9)
```bash
$ webviz
usage: Creates a Webviz Dash app from a configuration setup
       [-h] SUBCOMMAND ...
Creates a Webviz Dash app from a configuration setup: error: the following arguments are required: SUBCOMMAND
```

```bash
$ webviz --help

usage: Creates a Webviz Dash app from a configuration setup
       [-h] SUBCOMMAND ...

positional arguments:
  SUBCOMMAND   Below are the available subcommands listed. Type e.g. 'webviz
               build --help' to get help on one particular subcommand.
    build      Build a Webviz Dash App
    certificate
               Create a https certificate authority for webviz (validity
               limited to localhost only)
    docs       Get documentation on installed Webviz plugins
    preferences
               Set preferred webviz settings

optional arguments:
  -h, --help   show this help message and exit
```