### PR TITLE
Allow indented plugin docstrings + Indent rest of markdown docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 ### Added
 - [#269](https://github.com/equinor/webviz-config/pull/269) - Added an optional argument `screenshot_filename` to `WebvizPluginABC`. Can be used to let plugin authors specify filename used when screenshots of the plugin are saved.
+- [#275](https://github.com/equinor/webviz-config/pull/275) - Indented docstrings are now supported by `webviz docs`.
 
 ## [0.1.0] - 2020-08-24
 ### Added

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -1,0 +1,76 @@
+from webviz_config._docs._build_docs import _split_docstring
+
+
+def test_split_docstring():
+    tests = [
+        (
+            "This is a test with only description.",
+            ["This is a test with only description."],
+        ),
+        (
+            (
+                " This is a test with only description, "
+                "but which has leading and trailing spaces.  "
+            ),
+            [
+                (
+                    "This is a test with only description, "
+                    "but which has leading and trailing spaces."
+                )
+            ],
+        ),
+        (
+            "Test with some newlines\n\n  \n    and a 4 space indent",
+            ["Test with some newlines\n\n\nand a 4 space indent"],
+        ),
+        (
+            "Test with a \n    4 space and a \n  2 space indent\n",
+            ["Test with a \n  4 space and a \n2 space indent"],
+        ),
+        (
+            "Test with a \n    4 space and a \n  2 space indent\n",
+            ["Test with a \n  4 space and a \n2 space indent"],
+        ),
+        (
+            (
+                " This is a test with description, arguments and data input."
+                "\n\n    ---\n\n    The docstring is indented by 4 spaces:\n    "
+                "* The argument list has a sub list indented by 8 spaces\n        like this."
+                "\n    ---\n    The data input section is not very interesting."
+            ),
+            [
+                "This is a test with description, arguments and data input.\n",
+                (
+                    "\nThe docstring is indented by 4 spaces:\n"
+                    "* The argument list has a sub list indented by 8 spaces\n    like this."
+                ),
+                "The data input section is not very interesting.",
+            ],
+        ),
+        (
+            (
+                "\tThis is a test with description, arguments and data input,"
+                " where indents are made with tabs and not spaces-"
+                "\n\n\t---\n\n\tThe docstring is indented by 1 tab:\n"
+                "\t* The argument list has a sub list indented by 2 tabs\n\t\tlike this."
+                "\n\t---\n\tThe data input section is not very interesting."
+            ),
+            [
+                (
+                    "This is a test with description, arguments and data input,"
+                    " where indents are made with tabs and not spaces-\n"
+                ),
+                (
+                    "\nThe docstring is indented by 1 tab:\n"
+                    "* The argument list has a sub list indented by 2 tabs\n\tlike this."
+                ),
+                "The data input section is not very interesting.",
+            ],
+        ),
+        (
+            "This is a test with only description, which includes a linebreak.\n",
+            ["This is a test with only description, which includes a linebreak."],
+        ),
+    ]
+    for test in tests:
+        assert _split_docstring(test[0]) == test[1]

--- a/webviz_config/plugins/_markdown.py
+++ b/webviz_config/plugins/_markdown.py
@@ -93,12 +93,12 @@ class Markdown(WebvizPluginABC):
     Images are supported, and should in the markdown file be given as either
     relative paths to the markdown file itself, or as absolute paths.
 
-> The markdown syntax for images has been extended to support \
-providing width and/or height for individual images (optional). \
-To specify the dimensions write e.g.
-> ```markdown
-> ![width=40%,height=300px](./example_banner.png "Some caption")
-> ```
+    > The markdown syntax for images has been extended to support \
+    providing width and/or height for individual images (optional). \
+    To specify the dimensions write e.g.
+    > ```markdown
+    > ![width=40%,height=300px](./example_banner.png "Some caption")
+    > ```
 
     """
 


### PR DESCRIPTION
Support for plugin docstrings that are indented to be used with `webviz docs` and `webviz schema`.
Also added an indent in `Markdown` plugin as the `black` indent in #270 had skipped the quoted section (this might be a risk going forward).

---

### Contributor checklist

- [X] :tada: This PR closes #272 
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Support indented docstrings.
   - [X] Indented section of `Markdown` docstring.
- [X] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.

