### PR TITLE
Show all Python warnings in CI log

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -18,6 +18,8 @@ jobs:
 
   webviz-config:
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: default  # We want to see e.g. DeprecationWarnings    
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8']


### PR DESCRIPTION
It is useful to be able to see e.g. `DeprecationWarning`s in the CI log.

This change will make sure we get all warnings (except those filtered away by code using e.g. `filterwarnings`).