### PR TITLE
Alter order of WEBVIZ_ASSETS and WEBVIZ_STORAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ enforced by `webviz-config` (inline script hashes are added automatically).
 (including specifying MIME type). Before only `.zip` archives were supported.
 - [#281](https://github.com/equinor/webviz-config/pull/281) - Now uses `importlib` instead of `pkg_resources` for
 detecting plugin entry points and package versions.
+- [#306](https://github.com/equinor/webviz-config/pull/306) - Now runs `WEBVIZ_ASSETS.make_portable` before 
+`WEBVIZ_STORE.build_store` when building portables, as it usually takes shorter time, and therefore will give
+feedback quicker if something is wrong.
 
 ### Fixed
 - [#295](https://github.com/equinor/webviz-config/pull/295) - Menu width is now specified. This both ensures

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -58,6 +58,6 @@ for plugin in plugins:
     if hasattr(plugin, "add_webvizstore"):
         WEBVIZ_STORAGE.register_function_arguments(plugin.add_webvizstore())
 
-WEBVIZ_STORAGE.build_store()
-
 WEBVIZ_ASSETS.make_portable(Path(__file__).resolve().parent / "assets")
+
+WEBVIZ_STORAGE.build_store()


### PR DESCRIPTION
Altered order of `WEBVIZ_ASSETS.make_portable` and `WEBVIZ_STORAGE.build_store` as the `WEBVIZ_ASSETS.make_portable` usually is much quicker, and would then fail faster if you are e.g. referring to a non-existing file. 

---

### Contributor checklist

- [X] :tada: This PR closes #303.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Alter order of `WEBVIZ_ASSETS.make_portable` and  `WEBVIZ_STORAGE.build_store`
   - [X] Tested locally to build a portable of `examples/basic_example.yaml`
- ~~[ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.~~
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
