### PR TITLE
Resolve UnclosedFile+ResourceWarning + graceful exit on KeyboardInterrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ detecting plugin entry points and package versions.
 feedback quicker if something is wrong.
 
 ### Fixed
+- [#308](https://github.com/equinor/webviz-config/pull/308) - Fixed `UnclosedFile` and `Resource` warnings,
+which would appear if developer enabled e.g. `export PYTHONWARNINGS=default`. Also, Webviz now gracefully
+exits on CTRL+C (`KeyboardInterrupt`) instead of giving (unnecessary) traceback to the user.
 - [#295](https://github.com/equinor/webviz-config/pull/295) - Menu width is now specified. This both ensures
 the menu does not collapse if plugin content is wide, as well as not too wide itself if page titles are long
 (instead page titles in the menu are wrapped). Also added `<meta name="viewport" content="width=device-width, initial-scale=1">`

--- a/webviz_config/_build_webviz.py
+++ b/webviz_config/_build_webviz.py
@@ -84,7 +84,6 @@ def build_webviz(args: argparse.Namespace) -> None:
 
     finally:
         if not args.portable:
-            print(f"Deleting temporary folder {build_directory}")
             shutil.rmtree(build_directory)
 
 
@@ -103,9 +102,9 @@ def run_webviz(args: argparse.Namespace, build_directory: pathlib.Path) -> None:
     lastmtime = args.yaml_file.stat().st_mtime
 
     while app_process.poll() is None:
-        time.sleep(1)
-
         try:
+            time.sleep(1)
+
             if lastmtime != args.yaml_file.stat().st_mtime:
                 lastmtime = args.yaml_file.stat().st_mtime
                 write_script(
@@ -125,11 +124,21 @@ def run_webviz(args: argparse.Namespace, build_directory: pathlib.Path) -> None:
                 f"{terminal_colors.END}"
             )
 
+        except KeyboardInterrupt:
+            app_process.kill()
+            print(
+                f"\r{terminal_colors.BLUE}{terminal_colors.BOLD}"
+                " Shutting down the webviz application on user request."
+                f"{terminal_colors.END}"
+            )
+            app_process.wait()
+
         except Exception as excep:
             app_process.kill()
             print(
                 f"{terminal_colors.RED}{terminal_colors.BOLD}"
-                "Unexpected error. Killing the webviz dash application process."
+                "Unexpected error. Killing the webviz application process."
                 f"{terminal_colors.END}"
             )
+            app_process.wait()
             raise excep

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -149,7 +149,7 @@ class ConfigParser:
         ConfigParser.check_for_tabs_in_file(yaml_file)
 
         try:
-            self._configuration = yaml.safe_load(open(yaml_file, "r"))
+            self._configuration = yaml.safe_load(yaml_file.read_text())
         except yaml.MarkedYAMLError as excep:
             extra_info = (
                 f"There is something wrong in the configuration file {yaml_file}. "


### PR DESCRIPTION
---

### Contributor checklist

- [X] :tada: This PR closes #298 and closes #299.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Use `pathlib.Path.read_text()` instead of `with/open` context.
   - [X] Follow best practice and wait for subprocess to stop.
   - [X] Graceful exit on `KeyboardInterrupt`.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
