### PR TITLE
min-width on menu + let menu expand on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 in generated application regarding which Python executable (`sys.executable`) was used
 when building a portable application.
 
+### Fixed
+- [#313](https://github.com/equinor/webviz-config/pull/313) - Added `min-width` to menu CSS
+such that it does not collapse on wide content. In addition, make sure menu `width` is
+only specified on screen widths wide enough to be above the Dash `Tabs` provided breakpoint at
+`800px`.
+
 ## [0.1.3] - 2020-09-22
 ### Added
 - [#283](https://github.com/equinor/webviz-config/pull/283) - Auto-generated Webviz plugin documentation

--- a/webviz_config/static/assets/webviz_layout.css
+++ b/webviz_config/static/assets/webviz_layout.css
@@ -41,7 +41,6 @@ div.pageWrapper.tab-content {
     flex-direction: column;
     width: 100%;
     margin: 20px;
-
 }
 
 .layoutWrapper {
@@ -65,9 +64,15 @@ div.pageWrapper.tab-content {
     overflow-x: hidden;
     overflow-y: scroll;
     height: 100vh;
-    width: 25rem;
+    min-width: 30rem;
     scrollbar-width: thin;
     scrollbar-color: var(--menuBackground) var(--menuBackground); /* thumb and track color */
+}
+
+@media (min-width: 800px) {
+    .sideBar {
+        width: 30rem;
+    }
 }
 
 .sideBar:hover {


### PR DESCRIPTION
The menu still can "collapse" wrt. width if content is wide. Therefore adding a `min-width`.

Also, on small screens, the Dash provided `Tabs` have a break point at `800px`. We only want to specify menu width at screens larger than `800px` such that on small screens we utilize the available space.