### PR TITLE
Support plotly.js screenshot download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
-
 - [#230](https://github.com/equinor/webviz-config/pull/230) - Instead of using
 `dcc.Tabs` to give the impression of a "multipage app", webviz now uses `dcc.Link` and
 `dcc.Location`. This has two main advantages: Big applications can have significantly
@@ -17,6 +16,10 @@ an URL they can share with others in order to point them to the correct "page". 
 authors should check that persistence is set to `session` on Dash components they use
 if they want user selections to remain across "page" changes. In order to get more
 easily typed URLs, runtime generated page IDs now use `-` instead of `_` for spaces.
+
+### Fixed
+- [#321](https://github.com/equinor/webviz-config/pull/321) - Allowed for `blob:`
+in `img-src` CSP such that `plotly.js` "Download to png" works properly.
 
 ## [0.1.4] - 2020-09-24
 

--- a/webviz_config/_theme_class.py
+++ b/webviz_config/_theme_class.py
@@ -19,12 +19,12 @@ class WebvizConfigTheme:
                 "'self'",
                 "'unsafe-eval'",  # [2]
             ],
-            "img-src": ["'self'", "data:"],
+            "img-src": ["'self'", "data:", "blob:"],  # [3]
             "navigate-to": "'self'",
             "base-uri": "'self'",
             "form-action": "'self'",
-            "frame-ancestors": "'self'",  # [3]
-            "frame-src": "'self'",  # [3]
+            "frame-ancestors": "'self'",  # [4]
+            "frame-src": "'self'",  # [4]
             "object-src": "'self'",
             "plugin-types": "application/pdf",
         }
@@ -35,7 +35,10 @@ class WebvizConfigTheme:
                 (https://github.com/plotly/plotly.js/issues/2355)
             [2] unsafe-eval still needed for plotly.js bundle
                 (https://github.com/plotly/plotly.js/issues/897)
-            [3] We use 'self' instead of 'none' due to what looks like a Chromium bug,
+            [3] html2canvas in webviz-core-components needs "data:" in img-src to create
+                screenshots, while plotly.js "Download screenshot to png" requires
+                "blob:" in img-src.
+            [4] We use 'self' instead of 'none' due to what looks like a Chromium bug,
                 where e.g. pdf's included using <embed> is not rendered. Might be
                 related to https://bugs.chromium.org/p/chromium/issues/detail?id=1002610
         """


### PR DESCRIPTION
`plotly.js` "Download screenshot to png" requires `blob:` in `img-src` CSP.

---

### Contributor checklist

- [X] :tada: This PR closes #317.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
