### PR TITLE
Extract plugin distribution information on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#324](https://github.com/equinor/webviz-config/pull/324) - Now also `webviz-config`
 shipped plugins install themselves through the `webviz_config_plugins` entrypoints group.
+- [#325](https://github.com/equinor/webviz-config/pull/325) - Removed support for
+ad-hoc plugins as this is costly to maintain. Also, the `module.PluginName` notation in 
+configuration files can then in future be used fo distinguish between multiple plugin
+packages using the same plugin name.
+
+### Fixed
+- [#325](https://github.com/equinor/webviz-config/pull/325) - Support plugin projects
+that use different name for top level package and distribution name.
 
 ## [0.2.0] - 2020-10-06
 

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,11 @@ setup(
     python_requires="~=3.6",
     use_scm_version=True,
     zip_safe=False,
+    project_urls={
+        "Documentation": "https://equinor.github.io/webviz-config",
+        "Download": "https://pypi.org/project/webviz-config",
+        "Tracker": "https://github.com/equinor/webviz-config/issues",
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -1,0 +1,13 @@
+import webviz_config
+from webviz_config.plugins import metadata
+
+
+def test_webviz_config_metadata():
+    meta = metadata["BannerImage"]
+
+    assert meta["dist_name"] == "webviz-config"
+    assert meta["dist_version"] == webviz_config.__version__
+
+    assert meta["documentation_url"] == "https://equinor.github.io/webviz-config"
+    assert meta["download_url"] == "https://pypi.org/project/webviz-config"
+    assert meta["tracker_url"] == "https://github.com/equinor/webviz-config/issues"

--- a/webviz_config/plugins/__init__.py
+++ b/webviz_config/plugins/__init__.py
@@ -2,15 +2,45 @@
 the utility itself.
 """
 
+import inspect
+from typing import Optional
+
 try:
     # Python 3.8+
-    from importlib.metadata import entry_points  # type: ignore
+    # pylint: disable=ungrouped-imports
+    from importlib.metadata import distributions  # type: ignore
+    from typing import TypedDict  # type: ignore
 except ModuleNotFoundError:
     # Python < 3.8
-    from importlib_metadata import entry_points  # type: ignore
+    from importlib_metadata import distributions  # type: ignore
+    from typing_extensions import TypedDict  # type: ignore
 
-__all__ = []
 
-for entry_point in entry_points().get("webviz_config_plugins", []):
-    globals()[entry_point.name] = entry_point.load()
-    __all__.append(entry_point.name)
+class PluginDistInfo(TypedDict):
+    dist_name: str
+    dist_version: str
+    documentation_url: Optional[str]
+    download_url: Optional[str]
+    issue_url: Optional[str]
+
+
+metadata = {}
+
+for dist in distributions():
+    for entry_point in dist.entry_points:
+        if entry_point.group == "webviz_config_plugins":
+            project_urls = {
+                value.split(",")[0]: value.split(",")[1].strip()
+                for (key, value) in dist.metadata.items()
+                if key == "Project-URL"
+            }
+
+            metadata[entry_point.name] = {
+                "dist_name": dist.metadata["name"],
+                "dist_version": dist.version,
+                "documentation_url": project_urls.get("Documentation"),
+                "download_url": project_urls.get("Download"),
+                "tracker_url": project_urls.get("Tracker"),
+            }
+
+            globals()[entry_point.name] = entry_point.load()

--- a/webviz_config/templates/README.md.jinja2
+++ b/webviz_config/templates/README.md.jinja2
@@ -1,6 +1,6 @@
-# Plugin package {{ package_name }}
+# Plugin project {{ dist_name }}
 
-?> :bookmark: This documentation is valid for version `{{ package_doc["version"] }}` of `{{ package_name}}`. 
+?> :bookmark: This documentation is valid for version `{{ package_doc["dist_version"] }}` of `{{ dist_name}}`. 
 
 {% if package_doc["doc"] is not none %}   
 {{ package_doc["doc"] }}

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -8,18 +8,11 @@ from pathlib import Path, PosixPath, WindowsPath
 import dash
 
 import webviz_config
+import webviz_config.plugins
 from webviz_config.themes import installed_themes
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
-
-{% for module in _imports %}
-{%- if module is string -%}
-import {{ module }}
-{%- else -%}
-import {{ module[0] }} as {{ module[1] }}
-{%- endif %}
-{% endfor %}
 
 logging.getLogger().setLevel(logging.{{ loglevel }})
 
@@ -49,7 +42,7 @@ plugins = []
 {% for page in pages %}
 {% for content in page.content %}
 {% if content is not string %}
-plugins.append({{ content._call_signature[0] }})
+plugins.append(webviz_config.plugins.{{ content._call_signature[0] }})
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -15,19 +15,12 @@ import dash_core_components as dcc
 import dash_html_components as html
 from flask_talisman import Talisman
 import webviz_config
+import webviz_config.plugins
 import webviz_config.certificate
 from webviz_config.themes import installed_themes
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
-
-{% for module in _imports %}
-{%- if module is string -%}
-import {{ module }}
-{%- else -%}
-import {{ module[0] }} as {{ module[1] }}
-{%- endif %}
-{% endfor %}
 
 # We do not want to show INFO regarding werkzeug routing as that is too verbose,
 # however we want other log handlers (typically coming from webviz plugin dependencies)
@@ -83,7 +76,7 @@ else:
        {%- if content is string -%}
          dcc.Markdown(r"""{{ content }}""")
        {%- else -%}
-         {{ content._call_signature[0] }}.{{ content._call_signature[1] }}
+         webviz_config.plugins.{{ content._call_signature[0] }}.{{ content._call_signature[1] }}
        {%- endif -%}
        {{- "" if loop.last else ","}}
        {% endfor -%}

--- a/webviz_config/utils/_get_webviz_plugins.py
+++ b/webviz_config/utils/_get_webviz_plugins.py
@@ -1,0 +1,20 @@
+import types
+import typing
+import inspect
+
+from .._plugin_abc import WebvizPluginABC
+
+
+def _get_webviz_plugins(module: types.ModuleType) -> list:
+    """Returns a list of all Webviz plugins
+    in the module given as input.
+    """
+
+    def _is_webviz_plugin(obj: typing.Any) -> bool:
+        return (
+            inspect.isclass(obj)
+            and issubclass(obj, WebvizPluginABC)
+            and obj is not WebvizPluginABC
+        )
+
+    return inspect.getmembers(module, _is_webviz_plugin)


### PR DESCRIPTION
Closes #323.

This change enables us to automatically include plugin packages in Docker/cloud deployment, based on what the user have asked for in config.

Separately, it could also enable us to in plugin wrapper toolbar optionally later add buttons for link to plugin source/issue tracker, documentation...