### PR TITLE
Fix links on PyPI readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,25 @@
-from setuptools import setup, find_packages
-import re
 import os
+import re
+import pathlib
 
-def get_long_description():
-    with open('README.md', "r") as f:
-        raw_readme = f.read()
-    
-    if 'GITHUB_SHA' in os.environ:
-        full_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/blob/{os.environ['GITHUB_SHA']}/"
-        substituted_readme = re.sub('\\]\\((?!https)', '](' + full_url, raw_readme)
-        return substituted_readme
-    else:
-        return raw_readme
+from setuptools import setup, find_packages
+
+
+def get_long_description() -> str:
+    """Converts relative repository links to absolute URLs
+    if GITHUB_REPOSITORY and GITHUB_SHA environment variables exist.
+    If not, it returns the raw content in README.md.
+    """
+
+    raw_readme = pathlib.Path("README.md").read_text()
+
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    sha = os.environ.get("GITHUB_SHA")
+
+    if repository is not None and sha is not None:
+        full_url = f"https://github.com/{repository}/blob/{sha}/"
+        return re.sub(r"]\((?!https)", "](" + full_url, raw_readme)
+    return raw_readme
 
 
 TESTS_REQUIRES = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,18 @@
 from setuptools import setup, find_packages
+import re
+import os
 
-with open("README.md", "r") as fh:
-    LONG_DESCRIPTION = fh.read()
+def get_long_description():
+    with open('README.md', "r") as f:
+        raw_readme = f.read()
+    
+    if 'GITHUB_SHA' in os.environ:
+        full_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/blob/{os.environ['GITHUB_SHA']}/"
+        substituted_readme = re.sub('\\]\\((?!https)', '](' + full_url, raw_readme)
+        return substituted_readme
+    else:
+        return raw_readme
+
 
 TESTS_REQUIRES = [
     "bandit",
@@ -18,7 +29,7 @@ TESTS_REQUIRES = [
 setup(
     name="webviz-config",
     description="Configuration file support for webviz",
-    long_description=LONG_DESCRIPTION,
+    long_description=get_long_description(),
     long_description_content_type="text/markdown",
     url="https://github.com/equinor/webviz-config",
     author="R&T Equinor",


### PR DESCRIPTION
##hacktoberfestivus

Fixes relative links in the README.md in PyPi. The relative links are converted to the absolute ones, pointing at the relevant GitHub repo files, including commit information.

Contributors: The GreenTeam w/
torgeha
JoakimJohansen
antoneskov

---

### Contributor checklist

- [x] :tada: This PR closes #244 .
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
