### PR TITLE
Comply with latest version of mypy

### DIFF
--- a/webviz_config/generic_plugins/_markdown.py
+++ b/webviz_config/generic_plugins/_markdown.py
@@ -20,8 +20,8 @@ class _WebvizMarkdownExtension(Extension):
 
         super().__init__()
 
-    def extendMarkdown(self, md: markdown.core.Markdown) -> None:
-        md.inlinePatterns.register(
+    def extendMarkdown(self, md: markdown.Markdown) -> None:
+        md.inlinePatterns.register(  # type: ignore[attr-defined]
             item=_MarkdownImageProcessor(IMAGE_LINK_RE, md, self.base_path),
             name="image_link",
             priority=50,


### PR DESCRIPTION
It appears that the latest version of `mypy` (released today) does not see the method `inlinePatterns` of `markdown.Markdown`, probably due to it being dynamically created or similarly within the `markdown` package.