### PR TITLE
Bug fix in webviz docs for type hinted return values of plugin init f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.4] - 2020-12-04
+## [UNRELEASED] - YYYY-MM-DD
 
 ### Fixed
 - [#351](https://github.com/equinor/webviz-config/pull/351) - Fixed bug in automatically
 generated docs when having a defaulted input argument of type `pathlib.Path` in plugin
 arguments.
+- [#354](https://github.com/equinor/webviz-config/pull/354) - Fixed bug in automatically
+generated docs when having type hinted return value of plugin `__init__` functions.
 
 ## [0.2.3] - 2020-11-26
 

--- a/webviz_config/_docs/_build_docs.py
+++ b/webviz_config/_docs/_build_docs.py
@@ -90,7 +90,7 @@ def _document_plugin(plugin: Tuple[str, Any]) -> PluginInfo:
         arg_info["required"] = "default" not in arg_info
 
     for arg, annotation in argspec.annotations.items():
-        if arg not in SPECIAL_ARGS:
+        if arg not in SPECIAL_ARGS and arg != "return":
             plugin_info["arg_info"][arg]["typehint"] = annotation
             plugin_info["arg_info"][arg]["typehint_string"] = _annotation_to_string(
                 annotation


### PR DESCRIPTION
Bug fix in webviz docs for type hinted return values of plugin init functions
### Contributor checklist

- [X] :tada: This PR closes #353 .
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
