### PR TITLE
Bump pandas to >=1.0

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -22,11 +22,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
-        pandas-version: ["0.24.2", "1.1.4"] # 0.24.2 necessary as long as RHEL6 is used internally. Pinned to 1.1.4 due to pandas 1.1.5 bug with pylint https://github.com/pandas-dev/pandas/issues/38355
-        exclude:
-          # Skip Python 3.8 and Pandas 0.24.2 combination due to missing 3.8 wheel for that specific pandas version
-          - python-version: "3.8"
-            pandas-version: "0.24.2"
 
     steps:
       - name: 📖 Checkout commit locally
@@ -49,7 +44,7 @@ jobs:
 
       - name: 📦 Install webviz-config with dependencies
         run: |
-          pip install 'pandas==${{ matrix.pandas-version }}'
+          pip install 'pandas==1.1.4' # Pinned to 1.1.4 due to pandas 1.1.5 bug with pylint: https://github.com/pandas-dev/pandas/issues/38355
           pip install --upgrade pip
           pip install .
 
@@ -64,7 +59,7 @@ jobs:
         run: pip freeze
 
       - name: 🕵️ Check code style & linting
-        if: matrix.pandas-version == '1.*' && matrix.python-version == '3.8'
+        if: matrix.python-version == '3.8'
         run: |
           black --check webviz_config tests setup.py
           pylint webviz_config tests setup.py
@@ -80,7 +75,7 @@ jobs:
           webviz schema
 
       - name: 🚢 Build and deploy Python package
-        if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.pandas-version == '1.*'
+        if: github.event_name == 'release' && matrix.python-version == '3.6'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_webviz_token }}
@@ -90,7 +85,7 @@ jobs:
           twine upload dist/*
 
       - name: 📚 Update GitHub pages
-        if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.pandas-version == '1.*'
+        if: github.event_name == 'release' && matrix.python-version == '3.6'
         run: |
           cp -R ./docs_build ../docs_build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+- [#361](https://github.com/equinor/webviz-config/pull/361) - Bumped pandas requirement
+to `pandas>=1.0`, as `pandas==0.24.2` is no longer needed in internal deployment.
+
 ### Fixed
 - [#351](https://github.com/equinor/webviz-config/pull/351) - Fixed bug in automatically
 generated docs when having a defaulted input argument of type `pathlib.Path` in plugin

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "flask-talisman>=0.6",
         "jinja2>=2.10",
         "markdown>=3.0",
-        "pandas>=0.24",
+        "pandas>=1.0",
         "pyarrow>=0.16",
         "pyyaml>=5.1",
         "tqdm>=4.8",


### PR DESCRIPTION
Pandas `0.24.2` not needed for internal deployment anymore, bumping to `pandas>=1.0`

---

### Contributor checklist

- [X] :tada: This PR closes #360. 

- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
