### PR TITLE
Pin pip to 20.2.4 due to bug in black install

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 📦 Install webviz-config with dependencies
         run: |
           pip install 'pandas==1.1.4' # Pinned to 1.1.4 due to pandas 1.1.5 bug with pylint: https://github.com/pandas-dev/pandas/issues/38355
-          pip install --upgrade pip
+          pip install --upgrade pip==20.2.4 # Pinned to 20.2.4 for black install compatibility: https://github.com/psf/black/issues/1847
           pip install .
 
       - name: 📦 Install test dependencies


### PR DESCRIPTION
Pinning `pip==20.2.4` in CI due to [`black` install bug with `pip>=20.3`]( https://github.com/psf/black/issues/1847)

---

### Contributor checklist

- [X] :tada: This PR closes #363. 
