### PR TITLE
Make special (global) webviz_settings argument available to plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
+- [#368](https://github.com/equinor/webviz-config/pull/368) - Made Webviz global
+settings available to plugin implementations through special `webviz_settings` 
+argument. This argument is an instance of the `WebvizSettings` class and currently
+contains both the `shared_settings` and `theme` properties.
 - [#367](https://github.com/equinor/webviz-config/pull/367) - Made type information
-available to package consumers by indicating support for typing as specified in [PEP 561](https://www.python.org/dev/peps/pep-0561/).
+available to package consumers by indicating support for typing as specified in 
+[PEP 561](https://www.python.org/dev/peps/pep-0561/).
+
+### Deprecated
+- [#368](https://github.com/equinor/webviz-config/pull/368) - Access to `webviz_settings`
+as an attribute on the Dash application instance object (currently being passed to the
+plugins as the special `app` argument) has been deprecated.
 
 ## [0.2.4] - 2020-12-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -447,15 +447,37 @@ def subscribe(some_key, config_folder, portable):
     return some_key # The returned value here is put back into shared_settings["some_key"]
 ```
 
-The (optionally transformed) `shared_settings` are accessible to plugins through
-the `app` instance (see [callbacks](#callbacks)). E.g., in this case the wanted settings
-are found as `app.webviz_settings["shared_settings"]["some_key"]`.
-
 Stating the input arguments named `config_folder` and/or `portable` in the function
 signature is not necessary, however if you do you will get a
 [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path)
 instance representing the absolute path to the configuration file that was used, and/or
 a boolean value stating if the Webviz application running is a portable one.
+
+The (optionally transformed) `shared_settings` can be retrieved in a plugin by adding
+a specially named `webviz_settings` argument to the plugin's `__init__` function. The 
+`webviz_settings` argument works similar to the `app` argument in that it is a special 
+argument name that will not be originating from the configuration file, but will be 
+automatically given to the plugin by the core functionality of webviz-config. 
+
+Shared settings can then be accessed through `webviz_settings`. E.g., in the case 
+above, the wanted settings are found as `webviz_settings.shared_settings["some_key"]` 
+as shown in the example below:
+
+```python
+from webviz_config import WebvizPluginABC, WebvizSettings
+
+class ExamplePlugin(WebvizPluginABC):
+
+    def __init__(self, app, webviz_settings: WebvizSettings, title: str, number: int=42):
+
+        super().__init__()
+
+        self.title = title
+        self.number = number
+        self.some_key = webviz_settings.shared_settings["some_key"]
+
+        self.set_callbacks(app)
+```
 
 ### Custom ad-hoc plugins
 

--- a/tests/test_table_plotter.py
+++ b/tests/test_table_plotter.py
@@ -1,19 +1,23 @@
 import time
-import dash
+from pathlib import Path
 
+import dash
+from dash.testing.composite import DashComposite
+
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.themes import default_theme
 from webviz_config.generic_plugins import _table_plotter
 
 
-def test_table_plotter(dash_duo):
+def test_table_plotter(dash_duo: DashComposite) -> None:
 
     app = dash.Dash(__name__)
     app.config.suppress_callback_exceptions = True
     CACHE.init_app(app.server)
-    app.webviz_settings = {"theme": default_theme}
-    csv_file = "./tests/data/example_data.csv"
-    page = _table_plotter.TablePlotter(app, csv_file)
+    webviz_settings = WebvizSettings({}, default_theme)
+    csv_file = Path("./tests/data/example_data.csv")
+    page = _table_plotter.TablePlotter(app, webviz_settings, csv_file)
     app.layout = page.layout
     dash_duo.start_server(app)
 
@@ -41,14 +45,16 @@ def test_table_plotter(dash_duo):
         assert plot_option_dd.text == "Well"
 
 
-def test_table_plotter_filter(dash_duo):
+def test_table_plotter_filter(dash_duo: DashComposite) -> None:
 
     app = dash.Dash(__name__)
     app.config.suppress_callback_exceptions = True
     CACHE.init_app(app.server)
-    app.webviz_settings = {"theme": default_theme}
-    csv_file = "./tests/data/example_data.csv"
-    page = _table_plotter.TablePlotter(app, csv_file, filter_cols=["Well"])
+    webviz_settings = WebvizSettings({}, default_theme)
+    csv_file = Path("./tests/data/example_data.csv")
+    page = _table_plotter.TablePlotter(
+        app, webviz_settings, csv_file, filter_cols=["Well"]
+    )
     app.layout = page.layout
     dash_duo.start_server(app)
 
@@ -77,15 +83,15 @@ def test_table_plotter_filter(dash_duo):
         assert plot_option_dd.text == "Well"
 
 
-def test_initialized_table_plotter(dash_duo):
+def test_initialized_table_plotter(dash_duo: DashComposite) -> None:
 
     app = dash.Dash(__name__)
     app.css.config.serve_locally = True
     app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     CACHE.init_app(app.server)
-    app.webviz_settings = {"theme": default_theme}
-    csv_file = "./tests/data/example_data.csv"
+    webviz_settings = WebvizSettings({}, default_theme)
+    csv_file = Path("./tests/data/example_data.csv")
     plot_options = dict(
         x="Well",
         y="Initial reservoir pressure (bar)",
@@ -94,7 +100,7 @@ def test_initialized_table_plotter(dash_duo):
     )
 
     page = _table_plotter.TablePlotter(
-        app, csv_file, lock=True, plot_options=plot_options
+        app, webviz_settings, csv_file, lock=True, plot_options=plot_options
     )
     app.layout = page.layout
     dash_duo.start_server(app)

--- a/tests/unit_tests/test_webviz_settings.py
+++ b/tests/unit_tests/test_webviz_settings.py
@@ -1,11 +1,12 @@
-import pytest
-import sys
 from typing import cast
+
+import pytest
 
 from webviz_config import WebvizConfigTheme, WebvizSettings
 
 
 def test_construction_and_basic_access() -> None:
+    # pylint: disable=unidiomatic-typecheck
     the_shared_settings = {"somenumber": 10, "somestring": "abc"}
     the_theme = WebvizConfigTheme("dummyThemeName")
     settings_obj = WebvizSettings(the_shared_settings, the_theme)
@@ -28,8 +29,8 @@ def test_construction_and_basic_access() -> None:
 def test_construction_with_invalid_types() -> None:
     with pytest.raises(TypeError):
         theme = WebvizConfigTheme("dummyThemeName")
-        settings_obj = WebvizSettings(cast(dict, None), theme)
+        _settings_obj = WebvizSettings(cast(dict, None), theme)
 
     with pytest.raises(TypeError):
         shared_settings = {"somenumber": 10, "somestring": "abc"}
-        settings_obj = WebvizSettings(shared_settings, cast(WebvizConfigTheme, None))
+        _settings_obj = WebvizSettings(shared_settings, cast(WebvizConfigTheme, None))

--- a/tests/unit_tests/test_webviz_settings.py
+++ b/tests/unit_tests/test_webviz_settings.py
@@ -1,0 +1,35 @@
+import pytest
+import sys
+from typing import cast
+
+from webviz_config import WebvizConfigTheme, WebvizSettings
+
+
+def test_construction_and_basic_access() -> None:
+    the_shared_settings = {"somenumber": 10, "somestring": "abc"}
+    the_theme = WebvizConfigTheme("dummyThemeName")
+    settings_obj = WebvizSettings(the_shared_settings, the_theme)
+
+    copy_of_shared_settings = settings_obj.shared_settings
+    assert copy_of_shared_settings is not the_shared_settings
+    assert type(copy_of_shared_settings) == type(the_shared_settings)
+    assert copy_of_shared_settings == the_shared_settings
+    the_shared_settings["somestring"] = "MODIFIED"
+    assert copy_of_shared_settings != the_shared_settings
+
+    copy_of_theme = settings_obj.theme
+    assert copy_of_theme is not the_theme
+    assert type(copy_of_theme) == type(the_theme)
+    assert copy_of_theme.__dict__ == the_theme.__dict__
+    the_theme.theme_name = "MODIFIED"
+    assert copy_of_theme.__dict__ != the_theme.__dict__
+
+
+def test_construction_with_invalid_types() -> None:
+    with pytest.raises(TypeError):
+        theme = WebvizConfigTheme("dummyThemeName")
+        settings_obj = WebvizSettings(cast(dict, None), theme)
+
+    with pytest.raises(TypeError):
+        shared_settings = {"somenumber": 10, "somestring": "abc"}
+        settings_obj = WebvizSettings(shared_settings, cast(WebvizConfigTheme, None))

--- a/webviz_config/__init__.py
+++ b/webviz_config/__init__.py
@@ -6,6 +6,7 @@ except ModuleNotFoundError:
     from importlib_metadata import version, PackageNotFoundError  # type: ignore
 
 from ._theme_class import WebvizConfigTheme
+from ._webviz_settings_class import WebvizSettings
 from ._localhost_token import LocalhostToken
 from ._is_reload_process import is_reload_process
 from ._plugin_abc import WebvizPluginABC, EncodedFile, ZipFileMember

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -10,7 +10,7 @@ from . import plugins as standard_plugins
 from .utils import terminal_colors
 from .utils._get_webviz_plugins import _get_webviz_plugins
 
-SPECIAL_ARGS = ["self", "app", "_call_signature"]
+SPECIAL_ARGS = ["self", "app", "webviz_settings", "_call_signature"]
 
 
 def _call_signature(
@@ -113,6 +113,8 @@ def _call_signature(
     special_args = ""
     if "app" in argspec.args:
         special_args += "app=app, "
+    if "webviz_settings" in argspec.args:
+        special_args += "webviz_settings=webviz_settings, "
 
     return (
         f"{plugin_name}({special_args}**{kwargs})",

--- a/webviz_config/_webviz_settings_class.py
+++ b/webviz_config/_webviz_settings_class.py
@@ -1,0 +1,31 @@
+from typing import Dict, Any, Mapping
+
+from ._theme_class import WebvizConfigTheme
+
+
+class WebvizSettings:
+    """This class contains global Webviz settings that will be made available
+    to all plugins through the special argument named webviz_settings.
+    """
+
+    def __init__(
+        self, shared_settings: Dict[str, Any], theme: WebvizConfigTheme, portable: bool
+    ):
+        self._shared_settings = shared_settings
+        self._theme = theme
+        self._portable = portable
+
+    # TODO(Sigurd) How to type and what should we return here?
+    # For typing, either Dict or Mapping
+    # Do we just return our dict or should we make a copy?
+    @property
+    def shared_settings(self) -> Mapping[str, Any]:
+        return self._shared_settings
+
+    @property
+    def theme(self) -> WebvizConfigTheme:
+        return self._theme
+
+    @property
+    def portable(self) -> bool:
+        return self._portable

--- a/webviz_config/_webviz_settings_class.py
+++ b/webviz_config/_webviz_settings_class.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Dict, Any, Mapping
 
 from ._theme_class import WebvizConfigTheme
@@ -8,24 +9,20 @@ class WebvizSettings:
     to all plugins through the special argument named webviz_settings.
     """
 
-    def __init__(
-        self, shared_settings: Dict[str, Any], theme: WebvizConfigTheme, portable: bool
-    ):
+    def __init__(self, shared_settings: Dict[str, Any], theme: WebvizConfigTheme):
+        if not isinstance(shared_settings, dict):
+            raise TypeError("shared_settings must be of type dict")
+
+        if not isinstance(theme, WebvizConfigTheme):
+            raise TypeError("theme must be of type WebvizConfigTheme")
+
         self._shared_settings = shared_settings
         self._theme = theme
-        self._portable = portable
 
-    # TODO(Sigurd) How to type and what should we return here?
-    # For typing, either Dict or Mapping
-    # Do we just return our dict or should we make a copy?
     @property
     def shared_settings(self) -> Mapping[str, Any]:
-        return self._shared_settings
+        return copy.deepcopy(self._shared_settings)
 
     @property
     def theme(self) -> WebvizConfigTheme:
-        return self._theme
-
-    @property
-    def portable(self) -> bool:
-        return self._portable
+        return copy.deepcopy(self._theme)

--- a/webviz_config/generic_plugins/_table_plotter.py
+++ b/webviz_config/generic_plugins/_table_plotter.py
@@ -13,7 +13,7 @@ from dash.dependencies import Input, Output
 from dash import Dash
 import webviz_core_components as wcc
 
-from .. import WebvizPluginABC, EncodedFile
+from .. import WebvizPluginABC, WebvizSettings, EncodedFile
 from ..webviz_store import webvizstore
 from ..common_cache import CACHE
 
@@ -44,13 +44,14 @@ If feature is requested, the data could also come from a database.
     def __init__(
         self,
         app: Dash,
+        webviz_settings: WebvizSettings,
         csv_file: Path,
         plot_options: dict = None,
         filter_cols: list = None,
         filter_defaults: dict = None,
         column_color_discrete_maps: dict = None,
         lock: bool = False,
-    ):
+    ) -> None:
 
         super().__init__()
 
@@ -65,7 +66,16 @@ If feature is requested, the data could also come from a database.
         )
         self.filter_defaults = filter_defaults
         self.column_color_discrete_maps = column_color_discrete_maps
+
+        # !!!!
+        # TODO(Sigurd) Must be removed
+        # This will now give deprecation warning, if they are enabled
         self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+
+        # !!!!
+        # TODO(Sigurd) Remove comments
+        # This will now be the way to get hold of settings
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.set_callbacks(app)
 
     def set_filters(self, filter_cols: Optional[list]) -> None:

--- a/webviz_config/generic_plugins/_table_plotter.py
+++ b/webviz_config/generic_plugins/_table_plotter.py
@@ -66,15 +66,6 @@ If feature is requested, the data could also come from a database.
         )
         self.filter_defaults = filter_defaults
         self.column_color_discrete_maps = column_color_discrete_maps
-
-        # !!!!
-        # TODO(Sigurd) Must be removed
-        # This will now give deprecation warning, if they are enabled
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
-
-        # !!!!
-        # TODO(Sigurd) Remove comments
-        # This will now be the way to get hold of settings
         self.plotly_theme = webviz_settings.theme.plotly_theme
         self.set_callbacks(app)
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -4,6 +4,7 @@
 import logging
 import datetime
 from pathlib import Path, PosixPath, WindowsPath
+import warnings
 
 import dash
 
@@ -13,6 +14,7 @@ from webviz_config.themes import installed_themes
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
+from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
 logging.getLogger().setLevel(logging.{{ loglevel }})
 
@@ -22,12 +24,35 @@ theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_t
 app = dash.Dash()
 app.config.suppress_callback_exceptions = True
 
-app.webviz_settings = {
-    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
-        {{ shared_settings }}, {{ config_folder }}, False
+# Create the webviz_setting object that will get passed as an argument to 
+# all plugins that require it.
+# TODO(Sigurd) What should the value of portable be during this invocation of the plugins?
+# TODO(Sigurd) Does it even make sense to hav portable as a property on WebvizSettings?
+webviz_settings: webviz_config.WebvizSettings = webviz_config.WebvizSettings(
+    shared_settings=webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
+        {{ shared_settings }}, {{ config_folder }}, {{ False }} 
     ),
-    "theme": theme,
+    portable=False,
+    theme=theme,
+)
+
+# Previously, webviz_settings was piggybacked onto the Dash application object.
+# For a period of time, mark access to the webviz_settings attribute on 
+# the Dash application object as deprecated.
+deprecate_webviz_settings_attribute_in_dash_app()
+app._deprecated_webviz_settings = {
+    "shared_settings" : webviz_settings.shared_settings,
+    "theme" : webviz_settings.theme
 }
+
+
+# !!!!
+# !!!!
+# TODO(Sigurd) Must be removed
+# Hack for testing
+# To make deprecation warnings show
+warnings.simplefilter("default")
+
 
 CACHE.init_app(app.server)
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -4,7 +4,6 @@
 import logging
 import datetime
 from pathlib import Path, PosixPath, WindowsPath
-import warnings
 
 import dash
 
@@ -24,35 +23,23 @@ theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_t
 app = dash.Dash()
 app.config.suppress_callback_exceptions = True
 
-# Create the webviz_setting object that will get passed as an argument to 
-# all plugins that require it.
-# TODO(Sigurd) What should the value of portable be during this invocation of the plugins?
-# TODO(Sigurd) Does it even make sense to hav portable as a property on WebvizSettings?
+# Create the common webviz_setting object that will get passed as an
+# argument to all plugins that request it.
 webviz_settings: webviz_config.WebvizSettings = webviz_config.WebvizSettings(
     shared_settings=webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
         {{ shared_settings }}, {{ config_folder }}, {{ False }} 
     ),
-    portable=False,
     theme=theme,
 )
 
 # Previously, webviz_settings was piggybacked onto the Dash application object.
-# For a period of time, mark access to the webviz_settings attribute on 
-# the Dash application object as deprecated.
+# For a period of time, keep it but mark access to the webviz_settings attribute
+# on the Dash application object as deprecated.
 deprecate_webviz_settings_attribute_in_dash_app()
 app._deprecated_webviz_settings = {
     "shared_settings" : webviz_settings.shared_settings,
     "theme" : webviz_settings.theme
 }
-
-
-# !!!!
-# !!!!
-# TODO(Sigurd) Must be removed
-# Hack for testing
-# To make deprecation warnings show
-warnings.simplefilter("default")
-
 
 CACHE.init_app(app.server)
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -9,7 +9,6 @@ import logging
 import threading
 import datetime
 from pathlib import Path, PosixPath, WindowsPath
-import warnings
 
 import dash
 import dash_core_components as dcc
@@ -46,34 +45,24 @@ server = app.server
 app.title = "{{ title }}"
 app.config.suppress_callback_exceptions = True
 
-# Create the webviz_setting object that will get passed as an argument to 
-# all plugins that require it.
+# Create the common webviz_setting object that will get passed as an
+# argument to all plugins that request it.
 webviz_settings: webviz_config.WebvizSettings = webviz_config.WebvizSettings(
     shared_settings=webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
         {{ shared_settings }}, {{ config_folder }}, {{ portable }} 
     ),
-    portable={{ portable }},
     theme=theme,
 )
 
 # Previously, webviz_settings was piggybacked onto the Dash application object.
-# For a period of time, mark access to the webviz_settings attribute on 
-# the Dash application object as deprecated.
+# For a period of time, keep it but mark access to the webviz_settings attribute
+# on the Dash application object as deprecated.
 deprecate_webviz_settings_attribute_in_dash_app()
 app._deprecated_webviz_settings = {
     "shared_settings" : webviz_settings.shared_settings,
-    "portable" : webviz_settings.portable,
-    "theme" : webviz_settings.theme
+    "theme" : webviz_settings.theme,
+    "portable" : {{ portable }},
 }
-
-
-# !!!!
-# !!!!
-# TODO(Sigurd) Must be removed
-# Hack for testing
-# To make deprecation warnings show
-warnings.simplefilter("default")
-
 
 CACHE.init_app(server)
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -9,6 +9,7 @@ import logging
 import threading
 import datetime
 from pathlib import Path, PosixPath, WindowsPath
+import warnings
 
 import dash
 import dash_core_components as dcc
@@ -21,6 +22,7 @@ from webviz_config.themes import installed_themes
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
+from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
 # We do not want to show INFO regarding werkzeug routing as that is too verbose,
 # however we want other log handlers (typically coming from webviz plugin dependencies)
@@ -44,13 +46,34 @@ server = app.server
 app.title = "{{ title }}"
 app.config.suppress_callback_exceptions = True
 
-app.webviz_settings = {
-    "shared_settings": webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
-        {{ shared_settings }}, {{ config_folder }}, {{ portable }}
+# Create the webviz_setting object that will get passed as an argument to 
+# all plugins that require it.
+webviz_settings: webviz_config.WebvizSettings = webviz_config.WebvizSettings(
+    shared_settings=webviz_config.SHARED_SETTINGS_SUBSCRIPTIONS.transformed_settings(
+        {{ shared_settings }}, {{ config_folder }}, {{ portable }} 
     ),
-    "portable": {{ portable }},
-    "theme": theme,
+    portable={{ portable }},
+    theme=theme,
+)
+
+# Previously, webviz_settings was piggybacked onto the Dash application object.
+# For a period of time, mark access to the webviz_settings attribute on 
+# the Dash application object as deprecated.
+deprecate_webviz_settings_attribute_in_dash_app()
+app._deprecated_webviz_settings = {
+    "shared_settings" : webviz_settings.shared_settings,
+    "portable" : webviz_settings.portable,
+    "theme" : webviz_settings.theme
 }
+
+
+# !!!!
+# !!!!
+# TODO(Sigurd) Must be removed
+# Hack for testing
+# To make deprecation warnings show
+warnings.simplefilter("default")
+
 
 CACHE.init_app(server)
 

--- a/webviz_config/utils/__init__.py
+++ b/webviz_config/utils/__init__.py
@@ -2,3 +2,6 @@ from ._localhost_open_browser import LocalhostOpenBrowser
 from ._available_port import get_available_port
 from ._silence_flask_startup import silence_flask_startup
 from ._dash_component_utils import calculate_slider_step
+from ._deprecate_webviz_settings_attribute_in_dash_app import (
+    deprecate_webviz_settings_attribute_in_dash_app,
+)

--- a/webviz_config/utils/_deprecate_webviz_settings_attribute_in_dash_app.py
+++ b/webviz_config/utils/_deprecate_webviz_settings_attribute_in_dash_app.py
@@ -1,0 +1,27 @@
+from typing import Any
+import warnings
+
+import dash
+
+
+def _get_deprecated_webviz_settings(self: Any) -> dict:
+    warnings.warn(
+        "Accessing webviz_settings through the Dash application object has been deprecated",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # pylint: disable=protected-access
+    return self._deprecated_webviz_settings
+
+
+def deprecate_webviz_settings_attribute_in_dash_app() -> None:
+    """Helper that monkey patches dash.Dash application class so that access to
+    the webviz_settings via the Dash application instance attribute is reported
+    as being deprecated.
+    """
+    dash.Dash.webviz_settings = property(
+        _get_deprecated_webviz_settings,
+        None,
+        None,
+        "Property to mark webviz_settings access as deprecated",
+    )

--- a/webviz_config/utils/_deprecate_webviz_settings_attribute_in_dash_app.py
+++ b/webviz_config/utils/_deprecate_webviz_settings_attribute_in_dash_app.py
@@ -6,7 +6,8 @@ import dash
 
 def _get_deprecated_webviz_settings(self: Any) -> dict:
     warnings.warn(
-        "Accessing webviz_settings through the Dash application object has been deprecated",
+        "Accessing webviz_settings through the Dash application object has been deprecated, "
+        "see https://github.com/equinor/webviz-config/pull/368",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
Instead of piggybacking webviz_settings as an attribute onto the Dash application object, make (global) Webviz settings available to plugins through special argument `webviz_settings.` This argument is an instance of the `WebvizSettings` class.

This PR also deprecates access to webviz_settings as an attribute on the Dash application instance object that is currently being passed to the plugins as the special `app` argument. Also note that the new `WebvizSettings` class does not contain the `portable` attribute.

To start using the new scheme, and avoid the deprecated functionality, you will have to modify your plugin's `__init__()` function to include the special `webviz_settings` argument. E.g. change the signature from:
<pre>
def __init__(self, app: dash.Dash, csv_file: Path) -> None:
</pre>
to
<pre>
def __init__(self, app: dash.Dash, <b>webviz_settings: WebvizSettings</b>, csv_file: Path) -> None:
</pre>

And for accessing the settings you will have to replace code such as this:

```
the_shared_settings = app.webviz_settings["shared_settings"]
the_theme = app.webviz_settings["theme"]
```
with
```
the_shared_settings = webviz_settings.shared_settings
the_theme = webviz_settings.theme
```



Todos:
- [x] Update documentation
- [x] Update change log, including deprecation
- [x] Spawn new issue to refactor plugins in webviz-subsurface

---

### Contributor checklist

- [x] :tada: This PR closes #352 
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
