### PR TITLE
Fix for import of TypedDict for Python versions older than 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+## [0.2.5] - 2020-12-19
+
 ### Changed
 - [#367](https://github.com/equinor/webviz-config/pull/367) - Made type information
-available to package consumers by indicating support for typing as specified in [PEP 561](https://www.python.org/dev/peps/pep-0561/).
+available to package consumers by indicating support for typing as specified in 
+[PEP 561](https://www.python.org/dev/peps/pep-0561/).
 
 ## [0.2.4] - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Fixed
+- [#373](https://github.com/equinor/webviz-config/pull/373) - Fix for import of TypedDict 
+in Python versions older than 3.8. Check against Python version instead of using try-except.
+
 ## [0.2.5] - 2020-12-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+## [0.2.6] - 2021-01-07
+
 ### Fixed
 - [#373](https://github.com/equinor/webviz-config/pull/373) - Fix for import of TypedDict 
 in Python versions older than 3.8. Check against Python version instead of using try-except.

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -3,18 +3,15 @@ import abc
 import base64
 import zipfile
 import warnings
-
+import sys
 from uuid import uuid4
 from typing import List, Optional, Type, Union
 
-try:
-    # Python 3.8+
-    # pylint: disable=ungrouped-imports
-    from typing import TypedDict  # type: ignore
-except (ImportError, ModuleNotFoundError):
-    # Python < 3.8
-    from typing_extensions import TypedDict  # type: ignore
-
+# pylint: disable=wrong-import-position
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import bleach
 from dash.development.base_component import Component


### PR DESCRIPTION
The current way of importing TypedDict (for type hinting) using try-except seems to confuse mypy and causes errors during type checking. See for example in: https://github.com/equinor/webviz-subsurface/runs/1647251891?check_suite_focus=true

This PR fixes the issue by checking against Python version instead of using try-except during import.

See: 
https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks
and: 
https://github.com/python/typeshed/issues/3500#issuecomment-558398738


Also updated CHANGELOG to reflect the already published release 0.2.5