### PR TITLE
Fix MyPy 0.800 errors in Markdown plugin

### DIFF
--- a/webviz_config/generic_plugins/_markdown.py
+++ b/webviz_config/generic_plugins/_markdown.py
@@ -34,7 +34,7 @@ class _MarkdownImageProcessor(ImageInlineProcessor):
 
         super().__init__(image_link_re, md)
 
-    def handleMatch(self, m, data: str) -> tuple:  # type: ignore[no-untyped-def]
+    def handleMatch(self, m, data: str) -> tuple:  # type: ignore[no-untyped-def, override]
         image, start, index = super().handleMatch(m, data)
 
         if image is None or not image.get("title"):
@@ -43,7 +43,7 @@ class _MarkdownImageProcessor(ImageInlineProcessor):
         src = image.get("src")
         caption = image.get("title")
 
-        if src.startswith("http"):
+        if src is None or src.startswith("http"):
             raise ValueError(
                 f"Image path {src} has been given. Only images "
                 "available on the file system can be added."
@@ -57,7 +57,7 @@ class _MarkdownImageProcessor(ImageInlineProcessor):
         url = WEBVIZ_ASSETS.add(image_path)
 
         image_style = ""
-        for style_prop in image.get("alt").split(","):
+        for style_prop in image.get("alt", default="").split(","):
             prop, value = style_prop.split("=")
             if prop == "width":
                 image_style += f"width: {value};"


### PR DESCRIPTION
### Contributor checklist

- [X] :tada: This PR closes #385.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Decided to override incompatible return type in for error:
`    webviz_config/generic_plugins/_markdown.py:37: error: Return type "Tuple[Any, ...]" of "handleMatch" incompatible with return type "Union[Tuple[Element, int, int], Tuple[None, None, None]]" in supertype "InlineProcessor"  [override]`
As I would have to import another package for the `Element` class + the new type hint would be very long. Seems like we are not anymore allowed a courser type hint (in this case `tuple`) than in parent classes you override.
   - [X] The other errors were fixed by handling the possibility of `None` returned from the getters.

Has limited user interest, so skipped it from `CHANGELOG`. Tell me if you disagree.
