### PR TITLE
Reduce height of sidebar to prevent overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- [#415](https://github.com/equinor/webviz-config/pull/415) - Reduce height of main
+sidebar to prevent overflow.
 
 ### Changed
 - [#409](https://github.com/equinor/webviz-config/pull/409) - Relax Python test

--- a/webviz_config/static/assets/webviz_layout.css
+++ b/webviz_config/static/assets/webviz_layout.css
@@ -47,7 +47,7 @@
     flex-direction: column;
     overflow-x: hidden;
     overflow-y: scroll;
-    height: 100vh;
+    height: 98vh;
     min-width: 30rem;
     scrollbar-width: thin;
     scrollbar-color: var(--menuBackground) var(--menuBackground); /* thumb and track color */    


### PR DESCRIPTION
The height of the sidebar is such that a scrollbar is always shown on the web page.
Reducing the height a bit removes this and makes the layout cleaner.

---

### Contributor checklist

- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Reduce height of sidebar
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
