### PR TITLE
Add black lower version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_long_description() -> str:
 
 TESTS_REQUIRES = [
     "bandit",
-    "black",
+    "black>=20.8b1",
     "jsonschema",
     "mock",
     "mypy",


### PR DESCRIPTION
`black==19.*` and `black==20.*` have different styles. Ensure developers are using `black>=20`.