### PR TITLE
Remove deprecated 'plugin-types' CSP directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Requiring a formal Python project also enables useful features in the framework
 ### Fixed
 - [#415](https://github.com/equinor/webviz-config/pull/415) - Reduce height of main
 sidebar to prevent overflow.
+- [#422](https://github.com/equinor/webviz-config/pull/422) - Remove deprecated 'plugin-types' CSP directive.
 
 ## [0.2.9] - 2021-02-23
 

--- a/webviz_config/_theme_class.py
+++ b/webviz_config/_theme_class.py
@@ -26,7 +26,6 @@ class WebvizConfigTheme:
             "frame-ancestors": "'self'",  # [4]
             "frame-src": "'self'",  # [4]
             "object-src": "'self'",
-            "plugin-types": "application/pdf",
         }
 
         """


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types.

The CSP directive `plugin-types` have been deprecated, and is not recommended anymore.