### PR TITLE
Added centralized factory registry for sharing factories between plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
+- [#426](https://github.com/equinor/webviz-config/pull/426) - Added centralized factory
+registry exposed through `WEBVIZ_FACTORY_REGISTRY` for sharing factories between plugins.
 - [#318](https://github.com/equinor/webviz-config/pull/318) - `webviz-config`
 now facilitates automatically including necessary plugin projects as dependencies
 in generated Docker setup. Private repositories are also supported, however the

--- a/tests/unit_tests/test_webviz_factory_registry.py
+++ b/tests/unit_tests/test_webviz_factory_registry.py
@@ -38,10 +38,10 @@ def create_initialized_registry() -> WebvizFactoryRegistry:
 def test_uninitialized_access() -> None:
     registry = WebvizFactoryRegistry()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         _inst_info = registry.app_instance_info
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         _settings = registry.all_factory_settings
 
 
@@ -63,7 +63,7 @@ def test_multiple_initializations() -> None:
     registry = WebvizFactoryRegistry()
     registry.initialize(instance_info, {"MyFactory": "someValue"})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         registry.initialize(instance_info, {"MyFactory": "someValue"})
 
 

--- a/tests/unit_tests/test_webviz_factory_registry.py
+++ b/tests/unit_tests/test_webviz_factory_registry.py
@@ -1,0 +1,140 @@
+from typing import Optional
+from pathlib import Path
+import pytest
+
+from webviz_config.webviz_factory_registry import WebvizFactoryRegistry
+from webviz_config.webviz_instance_info import WebvizInstanceInfo
+from webviz_config.webviz_instance_info import WebvizRunMode
+
+# pylint: disable=no-self-use
+class FactoryA:
+    def create_obj_a(self) -> str:
+        return "A"
+
+
+class FactoryB:
+    def create_obj_b(self) -> str:
+        return "B"
+
+
+class FactoryBSub(FactoryB):
+    def create_obj_b_sub(self) -> str:
+        return "B_sub"
+
+
+def create_initialized_registry() -> WebvizFactoryRegistry:
+    instance_info = WebvizInstanceInfo(WebvizRunMode.NON_PORTABLE, Path("somePath"))
+    registry = WebvizFactoryRegistry()
+    registry.initialize(instance_info, {"MyFactory": "someValue"})
+    return registry
+
+
+def test_uninitialized_access() -> None:
+    registry = WebvizFactoryRegistry()
+
+    with pytest.raises(ValueError):
+        _inst_info = registry.app_instance_info
+
+    with pytest.raises(ValueError):
+        _settings = registry.all_factory_settings
+
+
+def test_initialization_and_basic_access() -> None:
+    registry = create_initialized_registry()
+
+    inst_info = registry.app_instance_info
+    assert inst_info.run_mode == WebvizRunMode.NON_PORTABLE
+
+    settings = registry.all_factory_settings
+    assert "MyFactory" in settings
+
+    factory = registry.get_factory(FactoryA)
+    assert factory is None
+
+
+def test_multiple_initializations() -> None:
+    instance_info = WebvizInstanceInfo(WebvizRunMode.NON_PORTABLE, Path("somePath"))
+    registry = WebvizFactoryRegistry()
+    registry.initialize(instance_info, {"MyFactory": "someValue"})
+
+    with pytest.raises(ValueError):
+        registry.initialize(instance_info, {"MyFactory": "someValue"})
+
+
+def test_set_get_factory() -> None:
+    registry = create_initialized_registry()
+
+    factory_a = FactoryA()
+    registry.set_factory(FactoryA, factory_a)
+
+    factory_b = FactoryB()
+    registry.set_factory(FactoryB, factory_b)
+
+    f_a: Optional[FactoryA] = registry.get_factory(FactoryA)
+    assert f_a is factory_a
+
+    f_b: Optional[FactoryB] = registry.get_factory(FactoryB)
+    assert f_b is factory_b
+
+
+def test_set_get_derived_factory() -> None:
+    registry = create_initialized_registry()
+
+    factory_b = FactoryB()
+    factory_b_sub = FactoryBSub()
+
+    registry.set_factory(FactoryB, factory_b)
+    registry.set_factory(FactoryBSub, factory_b_sub)
+    assert registry.get_factory(FactoryB) is factory_b
+    assert registry.get_factory(FactoryBSub) is factory_b_sub
+
+    # This should be fine
+    registry.set_factory(FactoryB, factory_b_sub)
+    assert registry.get_factory(FactoryB) is factory_b_sub
+
+    # This should not be legal, but cannot currently figure out how
+    # to disallow it using type hinting. Currently throws an exception
+    with pytest.raises(TypeError):
+        registry.set_factory(FactoryBSub, factory_b)
+
+
+def test_set_mismatched_factory_types() -> None:
+    registry = create_initialized_registry()
+
+    factory_a: FactoryA = FactoryA()
+    factory_b: FactoryB = FactoryB()
+    factory_b_sub: FactoryBSub = FactoryBSub()
+
+    # These four are legal
+    registry.set_factory(FactoryA, factory_a)
+    registry.set_factory(FactoryB, factory_b)
+    registry.set_factory(FactoryB, factory_b_sub)
+    registry.set_factory(FactoryBSub, factory_b_sub)
+
+    # The following setter calls are illegal, but can't figure out how
+    # to get type hinting to disallow them
+    # For now, we rely on exceptions
+    with pytest.raises(TypeError):
+        registry.set_factory(FactoryA, 123)
+    with pytest.raises(TypeError):
+        registry.set_factory(FactoryA, factory_b)
+    with pytest.raises(TypeError):
+        registry.set_factory(FactoryBSub, factory_b)
+
+
+def test_get_mismatched_factory_types() -> None:
+    registry = create_initialized_registry()
+
+    _f_a: Optional[FactoryA] = None
+    _f_b: Optional[FactoryB] = None
+    _f_b_sub: Optional[FactoryBSub] = None
+
+    # These four are legal and do indeed pass wrt type checking
+    _f_a = registry.get_factory(FactoryA)
+    _f_b = registry.get_factory(FactoryB)
+    _f_b = registry.get_factory(FactoryBSub)
+    _f_b_sub = registry.get_factory(FactoryBSub)
+
+    # These are rightly caught as errors by type checking, good
+    # _f_b = registry.get_factory(FactoryA)
+    # _f_b_sub = registry.get_factory(FactoryB)

--- a/tests/unit_tests/test_webviz_factory_registry.py
+++ b/tests/unit_tests/test_webviz_factory_registry.py
@@ -2,17 +2,18 @@ from typing import Optional
 from pathlib import Path
 import pytest
 
+from webviz_config.webviz_factory import WebvizFactory
 from webviz_config.webviz_factory_registry import WebvizFactoryRegistry
 from webviz_config.webviz_instance_info import WebvizInstanceInfo
 from webviz_config.webviz_instance_info import WebvizRunMode
 
 # pylint: disable=no-self-use
-class FactoryA:
+class FactoryA(WebvizFactory):
     def create_obj_a(self) -> str:
         return "A"
 
 
-class FactoryB:
+class FactoryB(WebvizFactory):
     def create_obj_b(self) -> str:
         return "B"
 
@@ -20,6 +21,11 @@ class FactoryB:
 class FactoryBSub(FactoryB):
     def create_obj_b_sub(self) -> str:
         return "B_sub"
+
+
+# pylint: disable=too-few-public-methods
+class UnrelatedFactory:
+    pass
 
 
 def create_initialized_registry() -> WebvizFactoryRegistry:
@@ -111,11 +117,14 @@ def test_set_mismatched_factory_types() -> None:
     registry.set_factory(FactoryB, factory_b_sub)
     registry.set_factory(FactoryBSub, factory_b_sub)
 
+    # These are rightly caught as errors by type checking since they don't derive from WebvizFactory
+    # registry.set_factory(UnrelatedFactory, UnrelatedFactory())
+    # registry.set_factory(FactoryA, UnrelatedFactory())
+    # registry.set_factory(FactoryA, 123)
+
     # The following setter calls are illegal, but can't figure out how
     # to get type hinting to disallow them
     # For now, we rely on exceptions
-    with pytest.raises(TypeError):
-        registry.set_factory(FactoryA, 123)
     with pytest.raises(TypeError):
         registry.set_factory(FactoryA, factory_b)
     with pytest.raises(TypeError):

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -71,6 +71,8 @@ plugins.append(webviz_config.plugins.{{ content._call_signature[0] }})
 {% endfor %}
 {% endfor %}
 
+WEBVIZ_FACTORY_REGISTRY.cleanup_resources_after_plugin_init()
+
 for plugin in plugins:
     if hasattr(plugin, "add_webvizstore"):
         WEBVIZ_STORAGE.register_function_arguments(plugin.add_webvizstore())

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -13,8 +13,7 @@ from webviz_config.themes import installed_themes
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
-from webviz_config.webviz_instance_info import WebvizRunMode
-from webviz_config.webviz_instance_info import WebvizInstanceInfo
+from webviz_config.webviz_instance_info import WebvizRunMode, WebvizInstanceInfo
 from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -13,6 +13,9 @@ from webviz_config.themes import installed_themes
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
+from webviz_config.webviz_instance_info import WebvizRunMode
+from webviz_config.webviz_instance_info import WebvizInstanceInfo
+from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
 logging.getLogger().setLevel(logging.{{ loglevel }})
@@ -43,7 +46,17 @@ app._deprecated_webviz_settings = {
 
 CACHE.init_app(app.server)
 
-WEBVIZ_STORAGE.storage_folder = Path(__file__).resolve().parent / "resources" / "webviz_storage"
+storage_folder = Path(__file__).resolve().parent / "resources" / "webviz_storage"
+
+WEBVIZ_STORAGE.storage_folder = storage_folder
+
+app_instance_info = WebvizInstanceInfo(WebvizRunMode.BUILDING_PORTABLE, storage_folder)
+{% if internal_factory_settings is defined %}
+factory_settings_dict = {{ internal_factory_settings }}
+{% else %}
+factory_settings_dict = None
+{% endif %}
+WEBVIZ_FACTORY_REGISTRY.initialize(app_instance_info, factory_settings_dict)
 
 # The lines below can be simplified when assignment
 # expressions become available in Python 3.8

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -84,12 +84,7 @@ WEBVIZ_ASSETS.portable = {{ portable }}
 
 run_mode = WebvizRunMode.PORTABLE if {{portable}} else WebvizRunMode.NON_PORTABLE
 app_instance_info = WebvizInstanceInfo(run_mode, storage_folder)
-{% if internal_factory_settings is defined %}
-factory_settings_dict = {{ internal_factory_settings }}
-{% else %}
-factory_settings_dict = None
-{% endif %}
-WEBVIZ_FACTORY_REGISTRY.initialize(app_instance_info, factory_settings_dict)
+WEBVIZ_FACTORY_REGISTRY.initialize(app_instance_info, {{ internal_factory_settings if internal_factory_settings is defined else None }})
 
 use_oauth2 = False
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -145,6 +145,8 @@ else:
             ])]),
         html.Div(className="pageContent", id="page-content")])
 
+WEBVIZ_FACTORY_REGISTRY.cleanup_resources_after_plugin_init()
+
 oauth2 = webviz_config.Oauth2(app.server) if use_oauth2 else None
 
 @app.callback(dash.dependencies.Output("page-content", "children"),

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -20,8 +20,7 @@ from webviz_config.themes import installed_themes
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
-from webviz_config.webviz_instance_info import WebvizRunMode
-from webviz_config.webviz_instance_info import WebvizInstanceInfo
+from webviz_config.webviz_instance_info import WebvizRunMode, WebvizInstanceInfo
 from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -20,6 +20,9 @@ from webviz_config.themes import installed_themes
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
+from webviz_config.webviz_instance_info import WebvizRunMode
+from webviz_config.webviz_instance_info import WebvizInstanceInfo
+from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
 # We do not want to show INFO regarding werkzeug routing as that is too verbose,
@@ -73,10 +76,21 @@ CACHE.init_app(server)
 theme.adjust_csp({"script-src": app.csp_hashes()}, append=True)
 Talisman(server, content_security_policy=theme.csp, feature_policy=theme.feature_policy, force_https=False, session_cookie_secure=False)
 
+storage_folder = Path(__file__).resolve().parent / "resources" / "webviz_storage"
+
 WEBVIZ_STORAGE.use_storage = {{portable}}
-WEBVIZ_STORAGE.storage_folder = Path(__file__).resolve().parent / "resources" / "webviz_storage"
+WEBVIZ_STORAGE.storage_folder = storage_folder
 
 WEBVIZ_ASSETS.portable = {{ portable }}
+
+run_mode = WebvizRunMode.PORTABLE if {{portable}} else WebvizRunMode.NON_PORTABLE
+app_instance_info = WebvizInstanceInfo(run_mode, storage_folder)
+{% if internal_factory_settings is defined %}
+factory_settings_dict = {{ internal_factory_settings }}
+{% else %}
+factory_settings_dict = None
+{% endif %}
+WEBVIZ_FACTORY_REGISTRY.initialize(app_instance_info, factory_settings_dict)
 
 use_oauth2 = False
 

--- a/webviz_config/webviz_factory.py
+++ b/webviz_config/webviz_factory.py
@@ -1,6 +1,9 @@
 class WebvizFactory:
     """Base class for all factories that want to register themselves in
     WebvizFactoryRegistry.
+
+    Note that this functionality is provisional/experimental, and will not necessarily
+    see a deprecation phase and "may deviate from the usual version semantics."
     """
 
     def cleanup_resources_after_plugin_init(self) -> None:

--- a/webviz_config/webviz_factory.py
+++ b/webviz_config/webviz_factory.py
@@ -1,0 +1,11 @@
+class WebvizFactory:
+    """Base class for all factories that want to register themselves in
+    WebvizFactoryRegistry.
+    """
+
+    def cleanup_resources_after_plugin_init(self):
+        """Will be called after all plugins have been initialized to allow the factory
+        to do clean-up of any temporary resources allocated during the initialization
+        phase. The base implementation does nothing, override this function to
+        perform factory-specific cleanup.
+        """

--- a/webviz_config/webviz_factory.py
+++ b/webviz_config/webviz_factory.py
@@ -3,7 +3,7 @@ class WebvizFactory:
     WebvizFactoryRegistry.
     """
 
-    def cleanup_resources_after_plugin_init(self):
+    def cleanup_resources_after_plugin_init(self) -> None:
         """Will be called after all plugins have been initialized to allow the factory
         to do clean-up of any temporary resources allocated during the initialization
         phase. The base implementation does nothing, override this function to

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -1,0 +1,84 @@
+from typing import Dict, TypeVar, Type, Optional, Any
+
+from .webviz_instance_info import WebvizInstanceInfo
+
+# pylint: disable=invalid-name
+T = TypeVar("T")
+
+
+class WebvizFactoryRegistry:
+    """Global registry for factories that allows the actual factory instances
+    to be shared between plugins. Also facilitates storage of optional factory
+    settings that are read from the YAML config file for later consumption when
+    an actual factory gets created and added to the registry.
+    The registry is exposed globally through WEBVIZ_FACTORY_REGISTRY below.
+    This is also the reason for the two-stage initialization approach. Note that
+    the registry instance is useless until the initialize() method has been called.
+    """
+
+    def __init__(self):
+        self._is_initialized: bool = False
+        self._app_instance_info: Optional[WebvizInstanceInfo] = None
+        self._factory_settings_dict: Dict[str, Any] = {}
+        self._factories: Dict[Type, Any] = {}
+
+    def initialize(
+        self,
+        app_instance_info: WebvizInstanceInfo,
+        factory_settings_dict: Optional[Dict[str, Any]],
+    ) -> None:
+        """Does the actual initialization of the object instance.
+        This function will be called as part of the webviz_app.py / jinja2 template.
+        """
+        if self._is_initialized:
+            raise ValueError("Registry already initialized")
+
+        if not isinstance(app_instance_info, WebvizInstanceInfo):
+            raise TypeError("app_instance_info must be of type WebvizInstanceInfo")
+        self._app_instance_info = app_instance_info
+
+        if factory_settings_dict:
+            if not isinstance(factory_settings_dict, dict):
+                raise TypeError("factory_settings_dict must be of type dict")
+            self._factory_settings_dict = factory_settings_dict
+
+        self._is_initialized = True
+
+    def set_factory(self, factory_class: Type[T], factory_obj: T) -> None:
+        if not self._is_initialized:
+            raise ValueError("Illegal access, factory registry is not initialized")
+
+        if not isinstance(factory_obj, factory_class):
+            raise TypeError("The type of the factory does not match factory_class")
+
+        self._factories[factory_class] = factory_obj
+
+    def get_factory(self, factory_class: Type[T]) -> Optional[T]:
+        if not self._is_initialized:
+            raise ValueError("Illegal access, factory registry is not initialized")
+
+        if not factory_class in self._factories:
+            return None
+
+        factory_obj = self._factories[factory_class]
+        if not isinstance(factory_obj, factory_class):
+            raise TypeError("The stored factory object has wrong type")
+
+        return factory_obj
+
+    @property
+    def all_factory_settings(self) -> Dict[str, Any]:
+        if not self._is_initialized:
+            raise ValueError("Illegal access, factory registry is not initialized")
+
+        return self._factory_settings_dict
+
+    @property
+    def app_instance_info(self) -> WebvizInstanceInfo:
+        if not self._is_initialized or self._app_instance_info is None:
+            raise ValueError("Illegal access, factory registry is not initialized")
+
+        return self._app_instance_info
+
+
+WEBVIZ_FACTORY_REGISTRY = WebvizFactoryRegistry()

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -16,7 +16,7 @@ class WebvizFactoryRegistry:
     the registry instance is useless until the initialize() method has been called.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._is_initialized: bool = False
         self._app_instance_info: Optional[WebvizInstanceInfo] = None
         self._factory_settings_dict: Dict[str, Any] = {}

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -1,9 +1,11 @@
 from typing import Dict, TypeVar, Type, Optional, Any
 
+from .webviz_factory import WebvizFactory
 from .webviz_instance_info import WebvizInstanceInfo
 
+
 # pylint: disable=invalid-name
-T = TypeVar("T")
+T = TypeVar("T", bound=WebvizFactory)
 
 
 class WebvizFactoryRegistry:
@@ -20,7 +22,7 @@ class WebvizFactoryRegistry:
         self._is_initialized: bool = False
         self._app_instance_info: Optional[WebvizInstanceInfo] = None
         self._factory_settings_dict: Dict[str, Any] = {}
-        self._factories: Dict[Type, Any] = {}
+        self._factories: Dict[Type, WebvizFactory] = {}
 
     def initialize(
         self,
@@ -65,6 +67,13 @@ class WebvizFactoryRegistry:
             raise TypeError("The stored factory object has wrong type")
 
         return factory_obj
+
+    def cleanup_resources_after_plugin_init(self):
+        if not self._is_initialized:
+            raise ValueError("Illegal access, factory registry is not initialized")
+
+        for factory in self._factories.values():
+            factory.cleanup_resources_after_plugin_init()
 
     @property
     def all_factory_settings(self) -> Dict[str, Any]:

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -68,7 +68,7 @@ class WebvizFactoryRegistry:
 
         return factory_obj
 
-    def cleanup_resources_after_plugin_init(self):
+    def cleanup_resources_after_plugin_init(self) -> None:
         if not self._is_initialized:
             raise RuntimeError("Illegal access, factory registry is not initialized")
 

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -33,7 +33,7 @@ class WebvizFactoryRegistry:
         This function will be called as part of the webviz_app.py / jinja2 template.
         """
         if self._is_initialized:
-            raise ValueError("Registry already initialized")
+            raise RuntimeError("Registry already initialized")
 
         if not isinstance(app_instance_info, WebvizInstanceInfo):
             raise TypeError("app_instance_info must be of type WebvizInstanceInfo")
@@ -48,7 +48,7 @@ class WebvizFactoryRegistry:
 
     def set_factory(self, factory_class: Type[T], factory_obj: T) -> None:
         if not self._is_initialized:
-            raise ValueError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Illegal access, factory registry is not initialized")
 
         if not isinstance(factory_obj, factory_class):
             raise TypeError("The type of the factory does not match factory_class")
@@ -57,7 +57,7 @@ class WebvizFactoryRegistry:
 
     def get_factory(self, factory_class: Type[T]) -> Optional[T]:
         if not self._is_initialized:
-            raise ValueError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Illegal access, factory registry is not initialized")
 
         if not factory_class in self._factories:
             return None
@@ -70,7 +70,7 @@ class WebvizFactoryRegistry:
 
     def cleanup_resources_after_plugin_init(self):
         if not self._is_initialized:
-            raise ValueError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Illegal access, factory registry is not initialized")
 
         for factory in self._factories.values():
             factory.cleanup_resources_after_plugin_init()
@@ -78,14 +78,14 @@ class WebvizFactoryRegistry:
     @property
     def all_factory_settings(self) -> Dict[str, Any]:
         if not self._is_initialized:
-            raise ValueError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Illegal access, factory registry is not initialized")
 
         return self._factory_settings_dict
 
     @property
     def app_instance_info(self) -> WebvizInstanceInfo:
         if not self._is_initialized or self._app_instance_info is None:
-            raise ValueError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Illegal access, factory registry is not initialized")
 
         return self._app_instance_info
 

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -85,7 +85,7 @@ class WebvizFactoryRegistry:
     @property
     def app_instance_info(self) -> WebvizInstanceInfo:
         if not self._is_initialized or self._app_instance_info is None:
-            raise RuntimeError("Illegal access, factory registry is not initialized")
+            raise RuntimeError("Factory registry is not initialized")
 
         return self._app_instance_info
 

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -16,6 +16,9 @@ class WebvizFactoryRegistry:
     The registry is exposed globally through WEBVIZ_FACTORY_REGISTRY below.
     This is also the reason for the two-stage initialization approach. Note that
     the registry instance is useless until the initialize() method has been called.
+
+    Note that this functionality is provisional/experimental, and will not necessarily
+    see a deprecation phase and "may deviate from the usual version semantics."
     """
 
     def __init__(self) -> None:

--- a/webviz_config/webviz_instance_info.py
+++ b/webviz_config/webviz_instance_info.py
@@ -1,0 +1,24 @@
+from enum import Enum
+from pathlib import Path
+
+
+class WebvizRunMode(Enum):
+    NON_PORTABLE = 1
+    PORTABLE = 2
+    BUILDING_PORTABLE = 3
+
+
+class WebvizInstanceInfo:
+    """Class containing global info regarding the running webviz app instance"""
+
+    def __init__(self, run_mode: WebvizRunMode, storage_folder: Path):
+        self._run_mode = run_mode
+        self._storage_folder = storage_folder
+
+    @property
+    def run_mode(self) -> WebvizRunMode:
+        return self._run_mode
+
+    @property
+    def storage_folder(self) -> Path:
+        return self._storage_folder


### PR DESCRIPTION
Added centralized/global `WebvizFactoryRegistry` that allows factories to be registered and shared between plugins. 
The class also facilitates storage of optional factory settings that are read from the YAML config file for later consumption when
an actual factory gets created and added to the registry.

The registry is merely managed and initialized by `webviz-config` and then exposed globally through `WEBVIZ_FACTORY_REGISTRY.`  Actual creation/registration of factories and subsequent retrival and use of factories will be done by the concrete factory classes and/or the plugins that utilize the factories. 

Note that currently, factory settings are not exposed publicly. Initial usage of these settings is assumed to be for experimental and internal tweaking purposes. The factory settings can be specified in the configuration file using the `internal_factory_settings` key, but the interpretation and usage of of the contained dictionary is left to the individual factory. A hypothetical section specifying factory settings could look something like this:

```yaml
internal_factory_settings:
  EnsembleTableProviderFactory:
    backing_implementation: arrow
    arrow_options:
      keep_files_open: yes
  EnsambleSummaryProviderFactory:
    backing_implementation: parquet
    parquet_options:
      keep_files_open: yes
      downcast_to_float: true
```

---

### Contributor checklist

- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.

