### PR TITLE
Moved `FutureWarnings` for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#429](https://github.com/equinor/webviz-config/pull/429) - Moved `FutureWarnings`
-from `deprecated_decorators.py` to `_config_parser.py`.
+from `deprecated_decorators.py` to `_config_parser.py`. Simplified deprecation warnings.
 
 ## [0.3.0] - 2021-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
-### Changed
+### Fixed
 - [#429](https://github.com/equinor/webviz-config/pull/429) - Moved `FutureWarnings`
 from `deprecated_decorators.py` to `_config_parser.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+- [#429](https://github.com/equinor/webviz-config/pull/429) - Moved `FutureWarnings`
+from `deprecated_decorators.py` to `_config_parser.py`.
+
 ## [0.3.0] - 2021-04-27
 
 ### Added

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -146,7 +146,7 @@ def _call_signature(
             if deprecation.argument_name in kwargs_including_defaults.keys():
                 deprecation_warnings.append(deprecation.short_message)
                 warnings.warn(
-                    """Deprecated Argument: '{}' with value '{}' in method '{}' in module '{}'
+                    """Deprecated Argument: '{}' with value '{}' in plugin '{}'
 ------------------------
 {}
 ===
@@ -154,8 +154,7 @@ def _call_signature(
 """.format(
                         deprecation.argument_name,
                         kwargs_including_defaults[deprecation.argument_name],
-                        deprecation.method_name,
-                        getattr(deprecation.method_reference, "__module__"),
+                        plugin_name,
                         deprecation.short_message,
                         deprecation.long_message,
                     ),
@@ -173,7 +172,7 @@ def _call_signature(
             if result:
                 deprecation_warnings.append(result[0])
                 warnings.warn(
-                    """Deprecated Argument(s): '{}' with value(s) '{}' in method '{}' in module '{}'
+                    """Deprecated Argument(s): '{}' with value(s) '{}' in plugin '{}'
 ------------------------
 {}
 ===
@@ -185,8 +184,7 @@ def _call_signature(
                             for key, value in kwargs_including_defaults.items()
                             if key in deprecation.argument_names
                         ],
-                        deprecation.method_name,
-                        getattr(deprecation.method_reference, "__module__"),
+                        plugin_name,
                         result[0],
                         result[1],
                     ),

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -122,6 +122,15 @@ def _call_signature(
     )
     if deprecated_plugin:
         deprecation_warnings.append(deprecated_plugin.short_message)
+        warnings.warn(
+            f"""Plugin {deprecated_plugin.class_reference} has been deprecated.
+------------------------
+{deprecated_plugin.short_message}
+===
+{deprecated_plugin.long_message}
+""",
+            FutureWarning,
+        )
 
     deprecations = _ds.DEPRECATION_STORE.get_stored_plugin_argument_deprecations(
         getattr(webviz_config.plugins, plugin_name).__init__

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -123,7 +123,7 @@ def _call_signature(
     if deprecated_plugin:
         deprecation_warnings.append(deprecated_plugin.short_message)
         warnings.warn(
-            f"""Plugin {deprecated_plugin.class_reference} has been deprecated.
+            f"""Plugin '{plugin_name}' has been deprecated.
 ------------------------
 {deprecated_plugin.short_message}
 ===
@@ -146,7 +146,7 @@ def _call_signature(
             if deprecation.argument_name in kwargs_including_defaults.keys():
                 deprecation_warnings.append(deprecation.short_message)
                 warnings.warn(
-                    """Deprecated Argument: {} with value '{}' in method {} in module {}
+                    """Deprecated Argument: '{}' with value '{}' in method '{}' in module '{}'
 ------------------------
 {}
 ===
@@ -173,7 +173,7 @@ def _call_signature(
             if result:
                 deprecation_warnings.append(result[0])
                 warnings.warn(
-                    """Deprecated Argument(s): {} with value '{}' in method {} in module {}
+                    """Deprecated Argument(s): '{}' with value(s) '{}' in method '{}' in module '{}'
 ------------------------
 {}
 ===

--- a/webviz_config/deprecation_decorators.py
+++ b/webviz_config/deprecation_decorators.py
@@ -1,6 +1,5 @@
 from typing import Dict, Union, Callable, Tuple, cast, Optional, List
 import inspect
-import warnings
 
 from ._plugin_abc import WebvizPluginABC
 from . import _deprecation_store as _ds
@@ -19,16 +18,6 @@ def deprecated_plugin(
                 short_message,
                 long_message,
             )
-        )
-
-        warnings.warn(
-            f"""Plugin {original_plugin} has been deprecated.
-------------------------
-{short_message}
-===
-{long_message}
-""",
-            FutureWarning,
         )
 
         return original_plugin


### PR DESCRIPTION
Moved `FutureWarnings` from `deprecated_decorators.py` to `_config_parser.py`.

Fixes #428.