### PR TITLE
Fixed setting of global log level for webviz application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#440](https://github.com/equinor/webviz-config/pull/440) - Fixed setting of global 
 log level for webviz application.
+
+## [0.3.1] - 2021-04-29
+
+### Fixed
 - [#429](https://github.com/equinor/webviz-config/pull/429) - Moved `FutureWarnings`
 from `deprecated_decorators.py` to `_config_parser.py`. Simplified deprecation warnings.
 - [#432](https://github.com/equinor/webviz-config/pull/432) - Replaced `WebvizPluginABC` type in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Fixed
+- [#440](https://github.com/equinor/webviz-config/pull/440) - Fixed setting of global 
+log level for webviz application.
 - [#429](https://github.com/equinor/webviz-config/pull/429) - Moved `FutureWarnings`
 from `deprecated_decorators.py` to `_config_parser.py`. Simplified deprecation warnings.
 - [#432](https://github.com/equinor/webviz-config/pull/432) - Replaced `WebvizPluginABC` type in

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -15,7 +15,7 @@ from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
-logging.getLogger().setLevel(logging.{{ loglevel }})
+logging.basicConfig(level=logging.{{ loglevel }})
 
 theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -25,8 +25,8 @@ from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 # We do not want to show INFO regarding werkzeug routing as that is too verbose,
 # however we want other log handlers (typically coming from webviz plugin dependencies)
 # to be set to user specified log level.
+logging.basicConfig(level=logging.{{ loglevel }})
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
-logging.getLogger().setLevel(logging.{{ loglevel }})
 
 theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())


### PR DESCRIPTION
Fixed the way global log level specified through the `--loglevel` command line argument is applied in awebviz application.

- [x] :tada: This PR closes #434.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
