### PR TITLE
Simplify installation instructions after upstream fixes

### DIFF
--- a/.github/workflows/webviz-config.yml
+++ b/.github/workflows/webviz-config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: 📦 Install webviz-config with dependencies
         run: |
-          pip install --upgrade pip==20.2.4 # Pinned to 20.2.4 for black install compatibility: https://github.com/psf/black/issues/1847
+          pip install --upgrade pip
           pip install . .[deployment]
 
       - name: 📦 Install test dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,10 +502,7 @@ To run tests it is necessary to first install the [selenium chrome driver](https
 Then install the Python development requirements:
 ```bash
 pip install .[tests]
-pip install dash[testing]
 ```
-The second of these commands appears to be necessary as long as
-[this `pip` issue is open](https://github.com/pypa/pip/issues/4957).
 
 You can then run the tests using
 ```bash

--- a/README.md
+++ b/README.md
@@ -47,12 +47,8 @@ The recommended and simplest way of installing `webviz-config` is to run
 pip install webviz-config
 ```
 
-> :warning: Unless you are using `pip` version `>=20.3` you should enable the new `pip`
-resolver when installing, i.e. `pip install --use-feature=2020-resolver webviz-config`.
-
 If you want to develop `webviz-config` and install the latest source code manually you
 can do something along the lines of:
-can run
 ```bash
 git clone git@github.com:equinor/webviz-config.git
 cd ./webviz-config
@@ -60,8 +56,8 @@ npm ci --ignore-scripts && npm run postinstall
 pip install -e .
 ```
 
-After installation, there is a console script named `webviz` available. You can test the installation by using the provided test
-configuration file,
+After installation, there is a console script named `webviz` available. You can test the
+installation by using the provided example configuration file,
 ```bash
 webviz build ./examples/basic_example.yaml
 ```

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def get_long_description() -> str:
 TESTS_REQUIRES = [
     "bandit",
     "black>=20.8b1",
+    "dash[testing]",
     "jsonschema",
     "mock",
     "mypy",


### PR DESCRIPTION
Now `black` has wheels on PyPI, and `pip` supports extras installed through extras.