### PR TITLE
Add dependencies as plugin project metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+- [#447](https://github.com/equinor/webviz-config/pull/447) - Plugin project dependencies
+(indirect and direct) are now included in `PLUGIN_PROJECT_METADATA`. This enables
+the generated Docker setup, when portable apps are built, to have the same dependency
+versions compared to what the user had installed when creating the portable app.
+
 ### Fixed
 - [#440](https://github.com/equinor/webviz-config/pull/440) - Fixed setting of global 
 log level for webviz application.

--- a/tests/test_docker_setup.py
+++ b/tests/test_docker_setup.py
@@ -40,7 +40,7 @@ from webviz_config._dockerize._create_docker_setup import get_python_requirement
 )
 def test_derived_requirements(distributions, requirements):
     with pytest.warns(None) as record:
-        assert requirements == get_python_requirements(distributions)
+        assert set(requirements).issubset(get_python_requirements(distributions))
         assert len(record) == len(
             [
                 metadata

--- a/tests/test_plugin_init.py
+++ b/tests/test_plugin_init.py
@@ -1,8 +1,17 @@
 import warnings
+import importlib
+
+try:
+    # Python 3.8+
+    # pylint: disable=ungrouped-imports
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Python < 3.8
+    import importlib_metadata
 
 import mock
 
-from webviz_config.plugins._utils import load_webviz_plugins_with_metadata
+import webviz_config.plugins._utils
 
 
 class DistMock:
@@ -27,10 +36,14 @@ dist_mock2 = DistMock([plugin_entrypoint_mock1], "dist_mock2")
 dist_mock3 = DistMock([plugin_entrypoint_mock2], "dist_mock3")
 
 
-def test_no_warning():
+def test_no_warning(monkeypatch):
+    # pylint: disable=protected-access
+    monkeypatch.setattr(importlib_metadata, "requires", lambda x: [])
+    importlib.reload(webviz_config.plugins._utils)
+
     globals_mock = {}
     with warnings.catch_warnings(record=True) as warn:
-        metadata, _ = load_webviz_plugins_with_metadata(
+        metadata, _ = webviz_config.plugins._utils.load_webviz_plugins_with_metadata(
             [dist_mock1, dist_mock3], globals_mock
         )
         assert len(warn) == 0, "Too many warnings"
@@ -40,10 +53,14 @@ def test_no_warning():
     assert "SomePlugin2" in globals_mock
 
 
-def test_warning_multiple():
+def test_warning_multiple(monkeypatch):
+    # pylint: disable=protected-access
+    monkeypatch.setattr(importlib_metadata, "requires", lambda x: [])
+    importlib.reload(webviz_config.plugins._utils)
+
     globals_mock = {}
     with warnings.catch_warnings(record=True) as warn:
-        metadata, _ = load_webviz_plugins_with_metadata(
+        metadata, _ = webviz_config.plugins._utils.load_webviz_plugins_with_metadata(
             [dist_mock1, dist_mock2], globals_mock
         )
 

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -11,3 +11,6 @@ def test_webviz_config_metadata():
     assert metadata["download_url"] == "https://pypi.org/project/webviz-config"
     assert metadata["source_url"] == "https://github.com/equinor/webviz-config"
     assert metadata["tracker_url"] == "https://github.com/equinor/webviz-config/issues"
+
+    assert "dash" in metadata["dependencies"]  # dash is a direct dependency
+    assert "flask" in metadata["dependencies"]  # flask is an indirect dependency


### PR DESCRIPTION
After this pull request, we increase the robustness of portable apps that are moved to cloud.

Before this PR we only ensured that the same version of `webviz-config` + all necessary plugin projects where the same, compared with what the user had installed when creating the portable app. After this PR we also ensure that sub-dependencies (direct+indirect) also have the same version in the generated Docker setup.


### Contributor checklist

- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Added new `dependencies` metadata in `PLUGIN_PROJECT_METADATA`.
   - [X] Used this new metadata in the generation of `requirements.txt` generated with the Docker setup.
- [X] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
