### PR TITLE
Adjusted Dash application logging to webviz's global logging mechanism.

### DIFF
--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -22,24 +22,23 @@ from webviz_config.webviz_store import WEBVIZ_STORAGE
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.utils import deprecate_webviz_settings_attribute_in_dash_app
 
-# We do not want to show INFO regarding werkzeug routing as that is too verbose,
-# however we want other log handlers (typically coming from webviz plugin dependencies)
-# to be set to user specified log level.
+# Start out by setting a sensible configuration for the root logger and setting a global 
+# loglevel. The (global) loglevel defaults to WARNING, but can be set by the user via 
+# the --loglevel argument. The call to basicConfig() should happen before any other logging 
+# related calls, see https://docs.python.org/3/library/logging.html#logging.basicConfig
 logging.basicConfig(level=logging.{{ loglevel }})
-logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())
 
 app = dash.Dash(
-    __name__,
+    name="webviz_app",
     external_stylesheets=theme.external_stylesheets,
     assets_folder=Path("resources") / "assets",
     meta_tags=[
         {"name": "viewport", "content": "width=device-width, initial-scale=1"}
     ],
 )
-app.logger.setLevel(logging.WARNING)
 
 # For signing session cookies
 app.server.secret_key = webviz_config.LocalhostToken.generate_token()
@@ -48,6 +47,13 @@ server = app.server
 
 app.title = "{{ title }}"
 app.config.suppress_callback_exceptions = True
+
+# Dash is very eager to configure its own logger by both adding a handler and hardcoding
+# the loglevel to INFO. Below we counteract both of these.
+# We do not want to show INFO regarding werkzeug routing as that is too verbose.
+app.logger.setLevel(logging.{{ loglevel }})
+app.logger.handlers.clear()
+logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 # Create the common webviz_setting object that will get passed as an
 # argument to all plugins that request it.


### PR DESCRIPTION
Enforce the user specified global log level for the Dash app logger instead of always setting it to WARNING.
Remove the log handler that Dash insits on adding by default. This handler should not be needed since a handler gets added when we call `logging.basicConfig()` and we currently end up with two handlers for the Dash app logger.
Hardwire Dash application name to 'webviz_app' when creating the application object (instead of using `__name__`)
