### PR TITLE
Set Dash/Flask application name back to `__name__`

### DIFF
--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -34,7 +34,7 @@ theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())
 
 app = dash.Dash(
-    name="webviz_app",
+    name=__name__,
     external_stylesheets=theme.external_stylesheets,
     assets_folder=Path("resources") / "assets",
     meta_tags=[


### PR DESCRIPTION
Set Dash/Flask application name back to `__name__` after experiencing some problems when deploying with gunicorn.
