### PR TITLE
Ignore false positive from `pylint`

### DIFF
--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-sequence-index
+
 import logging
 import os
 import time


### PR DESCRIPTION
Ignore false positive from `pylint` after recent `astroid` release. It does not understand the object returned by `azure-cli` at runtime.

The `pylint` exception could probably be removed after #459.