### PR TITLE
Changed callable signature type hint to be arbitrary

### DIFF
--- a/webviz_config/deprecation_decorators.py
+++ b/webviz_config/deprecation_decorators.py
@@ -26,7 +26,7 @@ def deprecated_plugin(
 
 
 def deprecated_plugin_arguments(
-    check: Union[Dict[str, str], Callable[[], Optional[Tuple[str, str]]]]
+    check: Union[Dict[str, str], Callable[..., Optional[Tuple[str, str]]]]
 ) -> Callable:
     def decorator(original_init_method: Callable) -> Callable:
         original_method_args = inspect.getfullargspec(original_init_method).args


### PR DESCRIPTION
Changed callable signature type hint to be arbitrary in `@deprecated_plugin_arguments` signature.