### PR TITLE
Remove 62.5% CSS IE workaround

### DIFF
--- a/webviz_config/static/assets/webviz_layout.css
+++ b/webviz_config/static/assets/webviz_layout.css
@@ -48,7 +48,7 @@
     overflow-x: hidden;
     overflow-y: scroll;
     height: 98vh;
-    min-width: 30rem;
+    min-width: 300px;
     scrollbar-width: thin;
     scrollbar-color: var(--menuBackground) var(--menuBackground); /* thumb and track color */    
 }
@@ -65,7 +65,7 @@
 
 @media (min-width: 800px) {
     .sideWrapper {
-        width: 30rem;
+        width: 300px;
     }
 }
 

--- a/webviz_config/themes/default_assets/default_theme.css
+++ b/webviz_config/themes/default_assets/default_theme.css
@@ -222,16 +222,8 @@ h1, h2, h3, h4, h5, h6, p, a, div, button {
 }
 /* Base Styles
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-/* NOTE
-html is set to 62.5% so that all the REM measurements throughout Skeleton
-are based on 10px sizing. So basically 1.5rem = 15px :) */
-html {
-  font-size: 62.5%;
-}
 
 body {
-  font-size: 1.5em;
-  /* currently ems cause chrome bug misinterpreting rems on body element */
   line-height: 1.6;
   font-weight: 400;
   font-family: var(--menuLinkFont);


### PR DESCRIPTION
We don't need to support IE anymore. Therefore remove the 62.5% workaround (see https://css-tricks.com/css-font-size/ for a good read).

The menu width in `px` should with this change be the same as before in `rem` (assuming browser default font size of `16 px`):
```
16 px * (62.5 %) * (30 rem) = 300 px
```