### PR TITLE
Simplify Radix/Docker setup

### DIFF
--- a/webviz_config/templates/Dockerfile.jinja2
+++ b/webviz_config/templates/Dockerfile.jinja2
@@ -48,8 +48,7 @@ RUN pip install -r requirements.txt
 FROM python:{{python_version_major}}.{{python_version_minor}}-slim
 
 # Changing to non-root user early
-RUN addgroup --gid 1234 appuser-group
-RUN useradd --create-home --uid 1234 --groups appuser-group appuser
+RUN useradd --create-home --uid 1234 appuser
 USER 1234
 WORKDIR /home/appuser
 

--- a/webviz_config/templates/radixconfig.yaml.jinja2
+++ b/webviz_config/templates/radixconfig.yaml.jinja2
@@ -61,7 +61,7 @@ spec:
               name: appstorage
               storage: {{ azure_storage_container_name }}
               path: /home/appuser/dash_app/resources
-              gid: 1234
+              uid: 1234
   dnsAppAlias:
     environment: prod
     component: auth


### PR DESCRIPTION
After testing with Radix and the Azure blob driver, it turns out we can also provide `uid` as input. Removing `group`.