### PR TITLE
When comparing timezones, explicitly use UTC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Fixed
+- [#498](https://github.com/equinor/webviz-config/pull/498) - Explicitly use UTC when comparing time zones in the `OAuth` implementation.
+
 ## [0.3.4] - 2021-08-30
 
 ### Fixed

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -77,7 +77,7 @@ class Oauth2:
             expiration_date = datetime.datetime.now(
                 datetime.timezone.utc
             ) + datetime.timedelta(seconds=expires_in - 60)
-            print("Access token expiration date:", expiration_date)
+            print("Access token expiration date (UTC):", expiration_date)
 
             # Set expiration date in the session
             flask.session["expiration_date"] = expiration_date
@@ -140,7 +140,7 @@ class Oauth2:
                 new_expiration_date = datetime.datetime.now(
                     datetime.timezone.utc
                 ) + datetime.timedelta(seconds=expires_in - 60)
-                print("New access token expiration date:", new_expiration_date)
+                print("New access token expiration date (UTC):", new_expiration_date)
 
                 # Set new expiration date in the session
                 flask.session["expiration_date"] = new_expiration_date

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -74,9 +74,9 @@ class Oauth2:
                 code=code, scopes=[self._scope], redirect_uri=redirect_uri
             )
             expires_in = tokens_result.get("expires_in")
-            expiration_date = datetime.datetime.now() + datetime.timedelta(
-                seconds=expires_in - 60
-            )
+            expiration_date = datetime.datetime.now(
+                datetime.timezone.utc
+            ) + datetime.timedelta(seconds=expires_in - 60)
             print("Access token expiration date:", expiration_date)
 
             # Set expiration date in the session
@@ -127,7 +127,7 @@ class Oauth2:
     def check_and_set_token_expiry(self) -> None:
         if flask.session.get("access_token"):
             expiration_date = flask.session["expiration_date"]
-            current_date = datetime.datetime.now()
+            current_date = datetime.datetime.now(datetime.timezone.utc)
             if current_date > expiration_date:
                 # Access token has expired
                 print("Access token has expired.")
@@ -137,9 +137,9 @@ class Oauth2:
                     scopes=[self._scope], account=self._accounts[0]
                 )
                 expires_in = renewed_tokens_result.get("expires_in")
-                new_expiration_date = datetime.datetime.now() + datetime.timedelta(
-                    seconds=expires_in - 60
-                )
+                new_expiration_date = datetime.datetime.now(
+                    datetime.timezone.utc
+                ) + datetime.timedelta(seconds=expires_in - 60)
                 print("New access token expiration date:", new_expiration_date)
 
                 # Set new expiration date in the session


### PR DESCRIPTION
If not setting a timezone, the timezone will be timezone naive. However, this will get serialized to a timezone-aware
timezone when being stored as a session object. This causes later comparisons to fail, since
we end up compariong timezone aware to timezone naive objects. Instead, always explicitly create timezone-aware datetimes

### Contributor checklist

- [x] :tada: This PR closes #497 
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
