### PR TITLE
Add optional `pylint` option `useless-suppression`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,7 @@
 [MESSAGES CONTROL]
 
 disable = bad-continuation, missing-docstring, duplicate-code, unspecified-encoding
+enable = useless-suppression
 
 [DESIGN]
 

--- a/tests/test_plugin_init.py
+++ b/tests/test_plugin_init.py
@@ -1,10 +1,9 @@
 import warnings
-import importlib
 from unittest import mock
+import importlib
 
 try:
     # Python 3.8+
-    # pylint: disable=ungrouped-imports
     import importlib.metadata as importlib_metadata
 except ImportError:
     # Python < 3.8

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -294,7 +294,7 @@ class ConfigParser:
         return page_id
 
     def clean_configuration(self) -> None:
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-many-branches
         """Various cleaning and checks of the raw configuration read
         from the user provided yaml configuration file.
         """

--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -1,5 +1,3 @@
-# pylint: disable=invalid-sequence-index
-
 import logging
 import os
 import time

--- a/webviz_config/_deployment/radix.py
+++ b/webviz_config/_deployment/radix.py
@@ -45,7 +45,7 @@ def website_online(url: str) -> bool:
 
 def radix_initial_deployment(github_slug: str, build_directory: pathlib.Path) -> None:
     """Creates a Radix configuration file."""
-    # pylint: disable=too-many-statements,too-many-locals
+    # pylint: disable=too-many-statements
 
     if not radix_cli.binary_available():
         raise RuntimeError(

--- a/webviz_config/_docs/_build_docs.py
+++ b/webviz_config/_docs/_build_docs.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, Optional, Tuple, List
 
 try:
     # Python 3.8+
-    # pylint: disable=ungrouped-imports
     from typing import TypedDict  # type: ignore
 except (ImportError, ModuleNotFoundError):
     # Python < 3.8

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -8,18 +8,16 @@ import urllib
 from uuid import uuid4
 from typing import List, Optional, Type, Union, Dict
 
-# pylint: disable=wrong-import-position
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 import bleach
 from dash.development.base_component import Component
 from dash.dependencies import Input, Output
 import jinja2
-
 import webviz_core_components as wcc
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class ZipFileMember(TypedDict):

--- a/webviz_config/generic_plugins/_table_plotter.py
+++ b/webviz_config/generic_plugins/_table_plotter.py
@@ -18,7 +18,7 @@ from ..webviz_store import webvizstore
 from ..common_cache import CACHE
 
 
-# pylint: disable=too-many-instance-attributes, too-many-arguments
+# pylint: disable=too-many-arguments
 class TablePlotter(WebvizPluginABC):
     """Adds a plotter to the webviz instance, using tabular data from a provided csv file.
 If feature is requested, the data could also come from a database.
@@ -62,9 +62,7 @@ If feature is requested, the data could also come from a database.
         self.set_filters(filter_cols)
         self.columns = list(self.data.columns)
         self.numeric_columns = list(
-            self.data.select_dtypes(  # PyCQA/pylint#4577 # pylint: disable=no-member
-                include=[np.number]
-            ).columns
+            self.data.select_dtypes(include=[np.number]).columns
         )
         self.filter_defaults = filter_defaults
         self.column_color_discrete_maps = column_color_discrete_maps

--- a/webviz_config/plugins/_utils.py
+++ b/webviz_config/plugins/_utils.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 
 try:
     # Python 3.8+
-    # pylint: disable=ungrouped-imports
     from typing import TypedDict  # type: ignore
     from importlib.metadata import requires, version, PackageNotFoundError  # type: ignore
 except ImportError:

--- a/webviz_config/themes/__init__.py
+++ b/webviz_config/themes/__init__.py
@@ -8,9 +8,7 @@ except ModuleNotFoundError:
 from .. import WebvizConfigTheme
 from ._default_theme import default_theme
 
-installed_themes = {  # pylint: disable=invalid-name
-    default_theme.theme_name: default_theme
-}
+installed_themes = {default_theme.theme_name: default_theme}
 
 __all__ = ["installed_themes"]
 

--- a/webviz_config/themes/_default_theme.py
+++ b/webviz_config/themes/_default_theme.py
@@ -5,7 +5,7 @@ from plotly.io import templates
 
 from webviz_config import WebvizConfigTheme
 
-default_theme = WebvizConfigTheme(theme_name="default")  # pylint: disable=invalid-name
+default_theme = WebvizConfigTheme(theme_name="default")
 
 default_theme.assets = glob.glob(
     str(pathlib.Path(__file__).resolve().parent / "default_assets" / "*")


### PR DESCRIPTION
Enabling `useless-suppression` ensures we don't have unnecessary/obsolete `# pylint: disable=...` in the code base.