### PR TITLE
Bugfix/radix oauth issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+- [#539](https://github.com/equinor/webviz-config/pull/539) - Support using oauth behind proxy, if silent refresh of oauth token fails, fall back to loud refresh of token instead of raising internal server error
+
 ## [0.3.6] - 2021-11-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -506,6 +506,8 @@ Internally, this is done by using a ProxyFix class, as described in the Flask [d
 
 Any omitted argument will be set to 0.
 
+Webviz will store the users oauth and refresh tokens in the flask session. To ensure that this session is treated consistently across server replicas, you should set the environment variable `WEBVIZ_SESSION_SECRET_KEY` to the same value in all replicas.
+
 To get the access token of the authenticated user in the flask session, use `flask.session.get("access_token")`.
 
 To get the expiration date of the token, use `flask.session.get("expiration_date")`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,6 +495,17 @@ The values can be found in the Azure AD configuration page. Short explanation of
 - `WEBVIZ_CLIENT_SECRET`: Webviz Azure AD app's client secret.
 - `WEBVIZ_SCOPE`: The API permission for this Webviz Azure AD app.
 
+If you are serving behind a proxy, you might need to configure trust for X-FORWARD headers.
+Internally, this is done by using a ProxyFix class, as described in the Flask [docs](https://flask.palletsprojects.com/en/2.0.x/deploying/wsgi-standalone/#proxy-setups). To enable the use of the ProxyFix class, set one or all of the following variables to an integer describing the number of trusted forwards:
+
+- `WEBVIZ_X_FORWARDED_FOR`: Corresponds to x_for of the ProxyFix class
+- `WEBVIZ_X_FORWARDED_PROTO`: Corresponds to x_proto of the ProxyFix class
+- `WEBVIZ_X_FORWARDED_HOST`: Corresponds to x_host of the ProxyFix class
+- `WEBVIZ_X_FORWARDED_PORT`: Corresponds to x_port of the ProxyFix class
+- `WEBVIZ_X_FORWARDED_PREFIX`: Corresponds to x_prefix of the ProxyFix class
+
+Any omitted argument will be set to 0.
+
 To get the access token of the authenticated user in the flask session, use `flask.session.get("access_token")`.
 
 To get the expiration date of the token, use `flask.session.get("expiration_date")`.

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -77,7 +77,7 @@ class LocalhostToken:
                 self._ott_validated = True
 
                 if self._oauth2:
-                    self._oauth2.check_access_token()
+                    return self._oauth2.check_access_token()
 
             else:
                 flask.abort(401)

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -77,13 +77,7 @@ class LocalhostToken:
                 self._ott_validated = True
 
                 if self._oauth2:
-                    # The session of the request does not contain access token, redirect to /login
-                    is_redirected, redirect_url = self._oauth2.is_empty_token()
-                    if is_redirected:
-                        return flask.redirect(redirect_url)
-
-                    # The session contains access token, check (and set) its expiration date
-                    self._oauth2.check_and_set_token_expiry()
+                    self._oauth2.check_access_token()
 
             else:
                 flask.abort(401)

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -47,7 +47,7 @@ class Oauth2:
 
         @self._app.route("/login")
         def _login_controller():  # type: ignore[no-untyped-def]
-            redirect_uri = get_auth_redirect_uri(flask.request.url_root)
+            redirect_uri = get_auth_redirect_uri()
 
             # First leg of Oauth2 authorization code flow
             auth_url = self._msal_app.get_authorization_request_url(
@@ -57,7 +57,7 @@ class Oauth2:
 
         @self._app.route("/auth-return")
         def _auth_return_controller():  # type: ignore[no-untyped-def]
-            redirect_uri = get_auth_redirect_uri(flask.request.url_root)
+            redirect_uri = get_auth_redirect_uri()
             returned_query_params = flask.request.args
 
             # There is an error from the first leg of Oauth2 authorization code flow
@@ -119,7 +119,7 @@ class Oauth2:
             and flask.request.path != "/login"
             and flask.request.path != "/auth-return"
         ):
-            login_uri = get_login_uri(flask.request.url_root)
+            login_uri = get_login_uri()
             return True, login_uri
 
         return False, ""
@@ -151,9 +151,9 @@ class Oauth2:
                 )
 
 
-def get_login_uri(url_root: str) -> str:
-    return url_root + "login"
+def get_login_uri() -> str:
+    return flask.url_for("_login_controller")
 
 
-def get_auth_redirect_uri(url_root: str) -> str:
-    return url_root + "auth-return"
+def get_auth_redirect_uri() -> str:
+    return flask.url_for("_auth_return_controller", _external=True)

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -32,7 +32,7 @@ class Oauth2:
         # Initiate oauth2 endpoints
         self.set_oauth2_endpoints()
 
-    def configure_proxy_trust(self):
+    def configure_proxy_trust(self) -> None:
         """Configure"""
         proxy_settings = {
             "x_for": os.environ.get("WEBVIZ_X_FORWARDED_FOR"),

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -34,7 +34,7 @@ class Oauth2:
 
     def configure_proxy_trust(self) -> None:
         """Configure"""
-        proxy_settings = {
+        _proxy_settings = {
             "x_for": os.environ.get("WEBVIZ_X_FORWARDED_FOR"),
             "x_proto": os.environ.get("WEBVIZ_X_FORWARDED_PROTO"),
             "x_host": os.environ.get("WEBVIZ_X_FORWARDED_HOST"),
@@ -42,8 +42,8 @@ class Oauth2:
             "x_prefix": os.environ.get("WEBVIZ_X_FORWARDED_PREFIX"),
         }
 
-        if any(x is not None for x in proxy_settings.values()):
-            proxy_settings = {k: int(v) if v else 0 for k, v in proxy_settings.items()}
+        if any(x is not None for x in _proxy_settings.values()):
+            proxy_settings = {k: int(v) if v else 0 for k, v in _proxy_settings.items()}
             self._app.wsgi_app = ProxyFix(self._app.wsgi_app, **proxy_settings)
 
     def set_oauth2_endpoints(self) -> None:

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -116,8 +116,8 @@ class Oauth2:
     def is_empty_token() -> Tuple[bool, str]:
         if (
             not flask.session.get("access_token")
-            and flask.request.path != "/login"
-            and flask.request.path != "/auth-return"
+            and flask.request.endpoint != "_login_controller"
+            and flask.request.endpoint != "_auth_return_controller"
         ):
             login_uri = get_login_uri()
             return True, login_uri

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -33,13 +33,13 @@ class Oauth2:
         self.set_oauth2_endpoints()
 
     def configure_proxy_trust(self):
-        """Configure """
+        """Configure"""
         proxy_settings = {
             "x_for": os.environ.get("WEBVIZ_X_FORWARDED_FOR"),
             "x_proto": os.environ.get("WEBVIZ_X_FORWARDED_PROTO"),
             "x_host": os.environ.get("WEBVIZ_X_FORWARDED_HOST"),
             "x_port": os.environ.get("WEBVIZ_X_FORWARDED_PORT"),
-            "x_prefix": os.environ.get("WEBVIZ_X_FORWARDED_PREFIX")
+            "x_prefix": os.environ.get("WEBVIZ_X_FORWARDED_PREFIX"),
         }
 
         if any(x is not None for x in proxy_settings.values()):
@@ -130,7 +130,6 @@ class Oauth2:
         is_redirected, redirect_url = self.is_empty_token()
         if is_redirected:
             return flask.redirect(redirect_url)
-    
 
     @staticmethod
     def is_empty_token() -> Tuple[bool, str]:
@@ -177,9 +176,7 @@ class Oauth2:
         ) + datetime.timedelta(seconds=expires_in - 60)
         print("New access token expiration date (UTC):", new_expiration_date)
 
-        return renewed_tokens_result.get(
-            "access_token"
-        ), new_expiration_date
+        return renewed_tokens_result.get("access_token"), new_expiration_date
 
 
 def get_login_uri() -> str:

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -118,11 +118,11 @@ class Oauth2:
         set in the session cookie.
         """
 
-        # pylint: disable=inconsistent-return-statements
         @self._app.before_request
         def _check_access_token():  # type: ignore[no-untyped-def]
-            self.check_access_token()
+            return self.check_access_token()
 
+    # pylint: disable=inconsistent-return-statements
     def check_access_token(self):  # type: ignore[no-untyped-def]
         self.check_and_set_token_expiry()
 
@@ -154,9 +154,11 @@ class Oauth2:
                     access_token, expiration_date = self.refresh_token_if_possible()
                     flask.session["access_token"] = access_token
                     flask.session["expiration_date"] = expiration_date
-                except Exception as e:
+                except Exception as exc:  # pylint: disable=broad-except
+                    # Catch all and any error here,
+                    # since in all cases an error means we want to force a loud login
                     print(
-                        f"Warning: error {e} encountered when trying to refresh access token.\n"
+                        f"Warning: error {exc} encountered when trying to refresh access token.\n"
                         "Clearing any stored access token info to force re-login"
                     )
                     if "access_token" in flask.session:

--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -44,7 +44,7 @@ class Oauth2:
 
         if any(x is not None for x in _proxy_settings.values()):
             proxy_settings = {k: int(v) if v else 0 for k, v in _proxy_settings.items()}
-            self._app.wsgi_app = ProxyFix(self._app.wsgi_app, **proxy_settings)
+            self._app.wsgi_app = ProxyFix(self._app.wsgi_app, **proxy_settings)  # type: ignore
 
     def set_oauth2_endpoints(self) -> None:
         """/login and /auth-return endpoints are added for Oauth2 authorization

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -46,7 +46,7 @@ app = Dash(
 
 # For signing session cookies
 # Use user provided environment variable if exists, otherwise generate fresh
-session_secret_key = os.environment.get("WEBVIZ_SESSION_SECRET_KEY")
+session_secret_key = os.environ.get("WEBVIZ_SESSION_SECRET_KEY")
 app.server.secret_key = session_secret_key or webviz_config.LocalhostToken.generate_token()
 
 server = app.server

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -7,6 +7,7 @@
 
 import logging
 import logging.config
+import os
 import threading
 import datetime
 from pathlib import Path, PosixPath, WindowsPath
@@ -44,7 +45,9 @@ app = Dash(
 )
 
 # For signing session cookies
-app.server.secret_key = webviz_config.LocalhostToken.generate_token()
+# Use user provided environment variable if exists, otherwise generate fresh
+session_secret_key = os.environment.get("WEBVIZ_SESSION_SECRET_KEY")
+app.server.secret_key = session_secret_key or webviz_config.LocalhostToken.generate_token()
 
 server = app.server
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -46,8 +46,7 @@ app = Dash(
 
 # For signing session cookies
 # Use user provided environment variable if exists, otherwise generate fresh
-session_secret_key = os.environ.get("WEBVIZ_SESSION_SECRET_KEY")
-app.server.secret_key = session_secret_key or webviz_config.LocalhostToken.generate_token()
+app.server.secret_key = os.environ.get("WEBVIZ_SESSION_SECRET_KEY") or webviz_config.LocalhostToken.generate_token()
 
 server = app.server
 


### PR DESCRIPTION
This pull request:

1. Allows setting proxy trust settings via environment variables, in order to correct how flask builds urls behind proxies.
2. Consistently uses flask's url building functions to build urls when creating oauth login urls
3. Adds an option to specify a secret that will be used by flask when signing cookies. This allows those cookies to be used consistently between server replicas
4. Catches exceptions when attempting to refresh access tokens, and trigger full re-login if any such exceptions occur.

Note that nr. 4 is something of a cop-out, as it does not help silently refresh tokens for radix deployments, but at least prevents a 500 error being presented to users. The current state remains problematic, since redirecting to login tends to destroy state.

---

### Contributor checklist

- [x] :tada: This PR closes #535. It partially closes #536 and (possibly, would want confirmation) #523
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] More idiomatic usage of flask functions to build urls
   - [x] Allow use of ProxyFix to improve working behind proxies
   - [x] Allow specifying the app's secret key as an environment variable
   - [x] Force re-login when exceptions occur during silent token refresh
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
