### PR TITLE
Workaround `pylint/astroid` bug

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,8 @@
+[MASTER]
+
+# As a temporary workaround for https://github.com/PyCQA/pylint/issues/4577
+init-hook = "import astroid; astroid.context.InferenceContext.max_inferred = 500"
+
 [MESSAGES CONTROL]
 
 disable = bad-continuation, missing-docstring, duplicate-code, unspecified-encoding

--- a/webviz_config/generic_plugins/_data_table.py
+++ b/webviz_config/generic_plugins/_data_table.py
@@ -48,9 +48,7 @@ If feature is requested, the data could also come from a database.
     def layout(self) -> dash_table.DataTable:
         return dash_table.DataTable(
             columns=[{"name": i, "id": i} for i in self.df.columns],
-            data=self.df.to_dict(  # PyCQA/pylint#4577 # pylint: disable=no-member
-                "records"
-            ),
+            data=self.df.to_dict("records"),
             sort_action="native" if self.sorting else "none",
             filter_action="native" if self.filtering else "none",
             page_action="native" if self.pagination else "none",

--- a/webviz_config/generic_plugins/_table_plotter.py
+++ b/webviz_config/generic_plugins/_table_plotter.py
@@ -59,9 +59,7 @@ If feature is requested, the data could also come from a database.
         self.set_filters(filter_cols)
         self.columns = list(self.data.columns)
         self.numeric_columns = list(
-            self.data.select_dtypes(  # pylint: disable=no-member
-                include=[np.number]
-            ).columns
+            self.data.select_dtypes(include=[np.number]).columns
         )
         self.filter_defaults = filter_defaults
         self.column_color_discrete_maps = column_color_discrete_maps


### PR DESCRIPTION
This centralizes the workaround in `.pylintrc` instead of `disables` necessary throughout the code base.