### PR TITLE
Remove `dash-bootstrap-components` `UserWarning` filter

### DIFF
--- a/webviz_config/plugins/__init__.py
+++ b/webviz_config/plugins/__init__.py
@@ -2,8 +2,6 @@
 the utility itself.
 """
 
-import warnings
-
 try:
     # Python 3.8+
     from importlib.metadata import distributions
@@ -14,16 +12,6 @@ except ModuleNotFoundError:
 from ._utils import load_webviz_plugins_with_metadata, PluginProjectMetaData
 
 
-with warnings.catch_warnings():
-    # As of Sep. 30th 2021, dash-bootstrap-components on PyPI
-    # (https://pypi.org/project/dash-bootstrap-components/)
-    # did not have a new version using dash==2.0 import statements.
-    # Ignore warnings temporarily from that module in order to not
-    # confuse end users.
-    warnings.filterwarnings(
-        "ignore", category=UserWarning, module="dash_bootstrap_components._table"
-    )
-
-    PLUGIN_METADATA, PLUGIN_PROJECT_METADATA = load_webviz_plugins_with_metadata(
-        distributions(), globals()
-    )
+PLUGIN_METADATA, PLUGIN_PROJECT_METADATA = load_webviz_plugins_with_metadata(
+    distributions(), globals()
+)


### PR DESCRIPTION
...since `dash-bootstrap-components` now have a release using the new `dash` import order (which ensures that the end user doesn't get `UserWarning`'s the user can't fix).