### PR TITLE
Implemented title option for BannerImage plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+- [#572](https://github.com/equinor/webviz-config/pull/572) - Added `title_position` for the BannerImage plugin, allowing the user to place the text at the top or at the bottom of the image.
+
 ## [0.3.8] - 2022-01-06
 
 ### Changed

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -30,6 +30,7 @@ Useful on e.g. the front page for introducing a field or project.
         color: str = "white",
         shadow: bool = True,
         height: int = 300,
+        title_position: str = "center",
     ):
 
         super().__init__()
@@ -39,16 +40,23 @@ Useful on e.g. the front page for introducing a field or project.
         self.color = color
         self.shadow = shadow
         self.height = height
+        self.title_position = title_position
 
         self.image_url = WEBVIZ_ASSETS.add(image)
 
     @property
     def layout(self) -> html.Div:
+        
+        if self.title_position == "top":
+            self.title_position = "start"
+        elif self.title_position == "bottom":
+            self.title_position = "end"
 
         style = {
             "color": self.color,
             "backgroundImage": f"url({self.image_url})",
             "height": f"{self.height}px",
+            "align-items": f"{self.title_position}"
         }
 
         if self.shadow:

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -19,9 +19,16 @@ Useful on e.g. the front page for introducing a field or project.
 * **`color`:** Color to be used for the font.
 * **`shadow`:** Set to `False` if you do not want text shadow for the title.
 * **`height`:** Height of the banner image (in pixels).
+* **`title_position`:** Position of title (either `center`, `top` or `bottom`).
 """
 
     TOOLBAR_BUTTONS: List[str] = []
+
+    CSS_TITLE_POSITIONS: Dict[str, str] = {
+        "top": "start",
+        "center": "center",
+        "bottom": "end",
+    }
 
     def __init__(
         self,
@@ -40,32 +47,25 @@ Useful on e.g. the front page for introducing a field or project.
         self.color = color
         self.shadow = shadow
         self.height = height
-        self.title_position = title_position
+
+        try:
+            self.css_title_position = BannerImage.CSS_TITLE_POSITIONS[title_position]
+        except KeyError as exc:
+            raise ValueError(
+                f"{title_position} not a valid position for banner image title. "
+                f"Valid options: {', '.join(BannerImage.CSS_TITLE_POSITIONS.keys())}"
+            ) from exc
 
         self.image_url = WEBVIZ_ASSETS.add(image)
 
     @property
     def layout(self) -> html.Div:
 
-        CSS_TITLE_POSITIONS: Dict[str, str] = {
-            "top": "start",
-            "center": "center",
-            "bottom": "end",
-        }
-
-        try:
-            if self.title_position not in CSS_TITLE_POSITIONS:
-                raise Exception(KeyError)
-        except KeyError:
-            print(
-                f"{self.title_position} is not a valid option. Try: 'bottom', 'center' or 'top'."
-            )
-
         style = {
             "color": self.color,
             "backgroundImage": f"url({self.image_url})",
             "height": f"{self.height}px",
-            "align-items": CSS_TITLE_POSITIONS[self.title_position],
+            "align-items": self.css_title_position,
         }
 
         if self.shadow:

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -46,7 +46,7 @@ Useful on e.g. the front page for introducing a field or project.
 
     @property
     def layout(self) -> html.Div:
-        
+
         if self.title_position == "top":
             self.title_position = "start"
         elif self.title_position == "bottom":
@@ -56,7 +56,7 @@ Useful on e.g. the front page for introducing a field or project.
             "color": self.color,
             "backgroundImage": f"url({self.image_url})",
             "height": f"{self.height}px",
-            "align-items": f"{self.title_position}"
+            "align-items": f"{self.title_position}",
         }
 
         if self.shadow:

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 from dash import html
 
@@ -47,16 +47,25 @@ Useful on e.g. the front page for introducing a field or project.
     @property
     def layout(self) -> html.Div:
 
-        if self.title_position == "top":
-            self.title_position = "start"
-        elif self.title_position == "bottom":
-            self.title_position = "end"
+        CSS_TITLE_POSITIONS: Dict[str, str] = {
+            "top": "start",
+            "center": "center",
+            "bottom": "end",
+        }
+
+        try:
+            if self.title_position not in CSS_TITLE_POSITIONS:
+                raise Exception(KeyError)
+        except KeyError:
+            print(
+                f"{self.title_position} is not a valid option. Try: 'bottom', 'center' or 'top'."
+            )
 
         style = {
             "color": self.color,
             "backgroundImage": f"url({self.image_url})",
             "height": f"{self.height}px",
-            "align-items": f"{self.title_position}",
+            "align-items": CSS_TITLE_POSITIONS[self.title_position],
         }
 
         if self.shadow:

--- a/webviz_config/static/assets/webviz_config.css
+++ b/webviz_config/static/assets/webviz_config.css
@@ -2,7 +2,6 @@
 
     display: flex;
     justify-content: center;
-    align-items: center;
     font-size: 300%;
 
     text-shadow: 0.05em 0.05em 0 rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
Users can now specify if they want the image to be placed on the top or on the bottom of the BannerImage (center is the default). This is done by the css property `align-items`.

---

### Contributor checklist

- [x] :tada: This PR closes #530 .
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Implement the `align-items` property on `_banner_image.py`.
   - [x] Remove `align-items` from `webviz_config.css`.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
