### PR TITLE
Remove obsolete `pylint` disable

### DIFF
--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -68,7 +68,7 @@ class LocalhostToken:
 
             if not self._ott_validated and self._ott == flask.request.args.get("ott"):
                 self._ott_validated = True
-                flask.g.set_cookie_token = True  # pylint: disable=assigning-non-slot
+                flask.g.set_cookie_token = True
                 return flask.redirect(flask.request.base_url)
 
             if self._cookie_token == flask.request.cookies.get(

--- a/webviz_config/webviz_factory_registry.py
+++ b/webviz_config/webviz_factory_registry.py
@@ -4,7 +4,6 @@ import warnings
 from .webviz_factory import WebvizFactory
 from .webviz_instance_info import WebvizInstanceInfo, WEBVIZ_INSTANCE_INFO
 
-# pylint: disable=invalid-name
 T = TypeVar("T", bound=WebvizFactory)
 
 


### PR DESCRIPTION
Something upstream has become more intelligent, so we can remove a couple of `pylint` `disable`s.