### PR TITLE
Changed plugin and file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+- [#602](https://github.com/equinor/webviz-config/pull/602) - Changed the file and plugin names from `ExampleContentWrapper` to `ExampleWlfPlugin`.
+
 ### Added
 - [#594](https://github.com/equinor/webviz-config/pull/594) - Added early testing of graphical user interface (GUI) for editing and creating Webviz configuration files. Run `webviz editor` to start the GUI.
 

--- a/examples/basic_example_wlf.yaml
+++ b/examples/basic_example_wlf.yaml
@@ -16,12 +16,12 @@ layout:
     - page: Front page
       icon: home
       content:
-       - ExampleContentWrapperPlugin:
+       - ExampleWlfPlugin:
            title: Example Plugin
            contact_person:
              email: kari.nordmann@equinor.com
              name: Kari Nordmann
              phone: "000000000"
 
-       - ExampleContentWrapperPlugin2:
+       - ExampleWlfPlugin2:
            title: Example Plugin 2

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
         "console_scripts": ["webviz=webviz_config.command_line:main"],
         "webviz_config_plugins": [
             "ExampleAssets = webviz_config.generic_plugins._example_assets:ExampleAssets",
-            "ExampleContentWrapperPlugin = webviz_config.generic_plugins._example_content_wrapper_plugin:ExampleContentWrapperPlugin",
-            "ExampleContentWrapperPlugin2 = webviz_config.generic_plugins._example_content_wrapper_plugin:ExampleContentWrapperPlugin2",
+            "ExampleWlfPlugin = webviz_config.generic_plugins._example_wlf_plugin:ExampleWlfPlugin",
+            "ExampleWlfPlugin2 = webviz_config.generic_plugins._example_wlf_plugin:ExampleWlfPlugin2",
             "ExampleDataDownload = webviz_config.generic_plugins._example_data_download:ExampleDataDownload",
             "ExamplePlugin = webviz_config.generic_plugins._example_plugin:ExamplePlugin",
             "ExamplePortable = webviz_config.generic_plugins._example_portable:ExamplePortable",

--- a/webviz_config/generic_plugins/_example_wlf_plugin.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin.py
@@ -448,7 +448,7 @@ class TableView(ViewABC):
             )
 
 
-class ExampleContentWrapperPlugin(WebvizPluginABC):
+class ExampleWlfPlugin(WebvizPluginABC):
     class Ids:
         # pylint: disable=too-few-public-methods
         PLOT_VIEW = "plot-view"
@@ -461,19 +461,19 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
         self.data = [(x, x * x) for x in range(0, 10)]
         self.title = title
 
-        self.add_view(PlotView(self.data), ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
-        self.add_view(TableView(self.data), ExampleContentWrapperPlugin.Ids.TABLE_VIEW)
+        self.add_view(PlotView(self.data), ExampleWlfPlugin.Ids.PLOT_VIEW)
+        self.add_view(TableView(self.data), ExampleWlfPlugin.Ids.TABLE_VIEW)
 
         self.settings_group = SharedSettingsGroup()
         self.add_shared_settings_group(
-            self.settings_group, ExampleContentWrapperPlugin.Ids.SHARED_SETTINGS
+            self.settings_group, ExampleWlfPlugin.Ids.SHARED_SETTINGS
         )
 
     @property
     def tour_steps(self) -> List[dict]:
         return [
             {
-                "id": self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                "id": self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .view_element(PlotView.Ids.TEXT)
                 .component_unique_id(TextViewElement.Ids.TEXT),
                 "content": "Greetings from your example plugin.",
@@ -483,31 +483,31 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
                 "content": "You can change here if this shall be friendly or not.",
             },
             {
-                "id": self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                "id": self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .view_element(PlotView.Ids.PLOT)
                 .component_unique_id(PlotViewElement.Ids.GRAPH),
                 "content": "Over here you see a plot that shows x² or x³.",
             },
             {
                 "id": self.settings_group.component_unique_id(
-                    ExampleContentWrapperPlugin.Ids.SHARED_SETTINGS
+                    ExampleWlfPlugin.Ids.SHARED_SETTINGS
                 ),
                 "content": "You can change here which exponent you prefer.",
             },
             {
-                "id": self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                "id": self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .settings_group(PlotView.Ids.PLOT_SETTINGS)
                 .component_unique_id(PlotViewSettingsGroup.Ids.COORDINATES_SELECTOR),
                 "content": "...and here you can swap the axes.",
             },
             {
-                "id": self.view(ExampleContentWrapperPlugin.Ids.TABLE_VIEW)
+                "id": self.view(ExampleWlfPlugin.Ids.TABLE_VIEW)
                 .view_element(TableView.Ids.TABLE)
                 .component_unique_id(TableViewElement.Ids.TABLE),
                 "content": "There is also a table visualizing the data.",
             },
             {
-                "id": self.view(ExampleContentWrapperPlugin.Ids.TABLE_VIEW)
+                "id": self.view(ExampleWlfPlugin.Ids.TABLE_VIEW)
                 .settings_group(TableView.Ids.TABLE_SETTINGS)
                 .component_unique_id(TableViewSettingsGroup.Ids.ORDER_SELECTOR),
                 "content": "You can change the order of the table here.",
@@ -517,7 +517,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
     def _set_callbacks(self) -> None:
         @callback(
             Output(
-                self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .view_element(PlotView.Ids.TEXT)
                 .component_unique_id(TextViewElement.Ids.TEXT)
                 .to_string(),
@@ -535,7 +535,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
 
         @callback(
             Output(
-                self.view(ExampleContentWrapperPlugin.Ids.TABLE_VIEW)
+                self.view(ExampleWlfPlugin.Ids.TABLE_VIEW)
                 .view_element(TableView.Ids.TEXT)
                 .component_unique_id(TextViewElement.Ids.TEXT)
                 .to_string(),
@@ -568,7 +568,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
 
         @callback(
             Output(
-                self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .settings_group(PlotView.Ids.PLOT_SETTINGS)
                 .component_unique_id(PlotViewSettingsGroup.Ids.COORDINATES_SELECTOR)
                 .to_string(),
@@ -603,7 +603,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
 
         @callback(
             Output(
-                self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                 .view_elements()[1]
                 .component_unique_id(PlotViewElement.Ids.GRAPH)
                 .to_string(),
@@ -617,7 +617,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
                     "value",
                 ),
                 Input(
-                    self.view(ExampleContentWrapperPlugin.Ids.PLOT_VIEW)
+                    self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
                     .settings_group(PlotView.Ids.PLOT_SETTINGS)
                     .component_unique_id(PlotViewSettingsGroup.Ids.COORDINATES_SELECTOR)
                     .to_string(),
@@ -657,7 +657,7 @@ class ExampleContentWrapperPlugin(WebvizPluginABC):
 
 
 @deprecated_plugin("This is an example plugin that should be removed.")
-class ExampleContentWrapperPlugin2(WebvizPluginABC):
+class ExampleWlfPlugin2(WebvizPluginABC):
     class Ids:
         # pylint: disable=too-few-public-methods
         PLOT_VIEW = "plot-view"
@@ -668,4 +668,4 @@ class ExampleContentWrapperPlugin2(WebvizPluginABC):
         self.data = [(x, x * x) for x in range(0, 10)]
         self.title = title
 
-        self.add_view(PlotView(self.data), ExampleContentWrapperPlugin2.Ids.PLOT_VIEW)
+        self.add_view(PlotView(self.data), ExampleWlfPlugin2.Ids.PLOT_VIEW)


### PR DESCRIPTION
This PR changes the file and plugin names from `ExampleContentWrapper` to `ExampleWlfPlugin`.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
