### PR TITLE
Replace plugin wrapper id string with plugin unique id string in PluginABC

### DIFF
--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -211,7 +211,7 @@ def create_storage_container(
     storage_account: str,
     container: str,
 ) -> None:
-    BlobServiceClient.from_connection_string(
+    BlobServiceClient.from_connection_string( # type: ignore[attr-defined]
         _connection_string(subscription, resource_group, storage_account)
     ).get_container_client(container).create_container()
 
@@ -241,7 +241,7 @@ def storage_container_upload_folder(
                 )
 
     async def _upload_blob() -> None:
-        async with ContainerClient.from_connection_string(
+        async with ContainerClient.from_connection_string( # type: ignore[attr-defined]
             _connection_string(subscription, resource_group, storage_name),
             container_name,
         ) as container_client:

--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -211,7 +211,7 @@ def create_storage_container(
     storage_account: str,
     container: str,
 ) -> None:
-    BlobServiceClient.from_connection_string( 
+    BlobServiceClient.from_connection_string(
         _connection_string(subscription, resource_group, storage_account)
     ).get_container_client(container).create_container()
 

--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -211,7 +211,7 @@ def create_storage_container(
     storage_account: str,
     container: str,
 ) -> None:
-    BlobServiceClient.from_connection_string( # type: ignore[attr-defined]
+    BlobServiceClient.from_connection_string(  # type: ignore[attr-defined]
         _connection_string(subscription, resource_group, storage_account)
     ).get_container_client(container).create_container()
 
@@ -241,7 +241,7 @@ def storage_container_upload_folder(
                 )
 
     async def _upload_blob() -> None:
-        async with ContainerClient.from_connection_string( # type: ignore[attr-defined]
+        async with ContainerClient.from_connection_string(  # type: ignore[attr-defined]
             _connection_string(subscription, resource_group, storage_name),
             container_name,
         ) as container_client:

--- a/webviz_config/_deployment/azure_cli.py
+++ b/webviz_config/_deployment/azure_cli.py
@@ -211,7 +211,7 @@ def create_storage_container(
     storage_account: str,
     container: str,
 ) -> None:
-    BlobServiceClient.from_connection_string(  # type: ignore[attr-defined]
+    BlobServiceClient.from_connection_string( 
         _connection_string(subscription, resource_group, storage_account)
     ).get_container_client(container).create_container()
 
@@ -241,7 +241,7 @@ def storage_container_upload_folder(
                 )
 
     async def _upload_blob() -> None:
-        async with ContainerClient.from_connection_string(  # type: ignore[attr-defined]
+        async with ContainerClient.from_connection_string(
             _connection_string(subscription, resource_group, storage_name),
             container_name,
         ) as container_client:

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -82,7 +82,7 @@ class LocalhostToken:
             else:
                 flask.abort(401)
 
-        @self._app.after_request  # type: ignore[arg-type]
+        @self._app.after_request
         def _set_cookie_token_in_response(
             response: flask.wrappers.Response,
         ) -> flask.wrappers.Response:

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -312,7 +312,7 @@ class WebvizPluginABC(abc.ABC):
         shared_settings = self.shared_settings_groups()
         if shared_settings is not None:
             settings = [
-                setting._wrapped_layout("", self._plugin_wrapper_id)
+                setting._wrapped_layout("", self._plugin_unique_id.to_string())
                 for setting in shared_settings
             ]
 
@@ -320,7 +320,7 @@ class WebvizPluginABC(abc.ABC):
             settings.extend(
                 [
                     setting._wrapped_layout(
-                        view[1].unique_id(), self._plugin_wrapper_id
+                        view[1].unique_id(), self._plugin_unique_id.to_string()
                     )
                     for setting in view[1].settings_groups()
                 ]
@@ -329,17 +329,13 @@ class WebvizPluginABC(abc.ABC):
         return settings
 
     @property
-    def _plugin_wrapper_id(self) -> str:
-        return f"plugin-wrapper-{self._plugin_unique_id}"
-
-    @property
     def plugin_data_output(self) -> Output:
         self._add_download_button = True
-        return Output(self._plugin_wrapper_id, "download")
+        return Output(self._plugin_unique_id.to_string(), "download")
 
     @property
     def plugin_data_requested(self) -> Input:
-        return Input(self._plugin_wrapper_id, "data_requested")
+        return Input(self._plugin_unique_id.to_string(), "data_requested")
 
     @staticmethod
     def _reformat_tour_steps(steps: List[dict]) -> List[dict]:
@@ -495,7 +491,7 @@ class WebvizPluginABC(abc.ABC):
             for store in self._stores
         ] + [
             wcc.WebvizPluginWrapper(
-                id=self._plugin_wrapper_id,
+                id=self._plugin_unique_id.to_string(),
                 name=type(self).__name__,
                 views=[
                     {
@@ -535,7 +531,7 @@ class WebvizPluginABC(abc.ABC):
 
     def _set_wrapper_callbacks(self) -> None:
         @callback(
-            Output(self._plugin_wrapper_id, "children"),
+            Output(self._plugin_unique_id.to_string(), "children"),
             Input("webviz-content-manager", "activeViewId"),
             Input("webviz-content-manager", "activePluginId"),
         )
@@ -552,7 +548,7 @@ class WebvizPluginABC(abc.ABC):
             if initial_call:
                 view_id = self.active_view_id
 
-            if plugin_id == self._plugin_wrapper_id or initial_call:
+            if plugin_id == self._plugin_unique_id.to_string() or initial_call:
                 view = next(
                     (
                         view[1]


### PR DESCRIPTION
Remove unnecessary plugin wrapper id string from PluginABC - rather utilize plugin unique id string