### PR TITLE
Fix missing download button for old layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,10 @@ pages:
 ### Override plugin toolbar
 
 In the generated webviz application, your plugin will as default be given
-a button toolbar. The default buttons to appear is stored in the class constant
-`WebvizPluginABC.TOOLBAR_BUTTONS`. If you want to override which buttons should
-appear, redefine this class constant in your subclass. To remove all buttons,
-simply define it as an empty list. See [this section](#data-download-callback)
+a set of toolbar buttons in a settings drawer. The default buttons to appear are
+fullscreen and screenshot. Additional buttons appears based on provided
+information - as plugin author contact information, download data, guided tour
+information and issue feedback link. See [this section](#data-download-callback)
 for more information regarding downloading plugin data.
 
 ### Callbacks

--- a/webviz_config/_localhost_token.py
+++ b/webviz_config/_localhost_token.py
@@ -82,7 +82,7 @@ class LocalhostToken:
             else:
                 flask.abort(401)
 
-        @self._app.after_request  # type: ignore[arg-type]
+        @self._app.after_request
         def _set_cookie_token_in_response(
             response: flask.wrappers.Response,
         ) -> flask.wrappers.Response:

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -453,16 +453,14 @@ class WebvizPluginABC(abc.ABC):
         plugin_deprecation_warnings: Optional[List[str]] = None,
         argument_deprecation_warnings: Optional[List[str]] = None,
     ) -> List[Component]:
-        """This function returns (if the class constant SHOW_TOOLBAR is True,
-        the plugin layout wrapped into a common webviz config plugin
-        component, which provides some useful buttons like download of data,
-        show data contact person and download plugin content to png.
+        """This function returns plugin layour placed within a WebvizPluginWrapper
+        component, which contains a settings drawer with useful buttons like fullscreen
+        and screenshot of plugin content. Additional buttons as plugin author contact
+        information, download of data, guided tour, issue feedback link, etc. will appear
+        based on provided information.
 
-        CSV download button will only appear if the plugin class has a property
-        `csv_string` which should return the appropriate csv data as a string.
-
-        If `TOOLBAR_BUTTONS` is empty, this functions returns the same
-        dash layout as the plugin class provides directly.
+        Button for download of data will only appear if corresponding
+        callback functionality is implemented for the respective plugin.
         """
 
         self._set_all_callbacks()

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -131,6 +131,8 @@ class WebvizPluginABC(abc.ABC):
         self._stretch = stretch
         self._all_callbacks_set = False
 
+        self._legacy_plugin_view_id = f"{self._plugin_unique_id.to_string()}-view"
+
         self._set_wrapper_callbacks()
 
     def uuid(self, element: Optional[str] = None) -> str:
@@ -321,9 +323,7 @@ class WebvizPluginABC(abc.ABC):
 
         return settings
 
-    @property
-    def _legacy_plugin_view_id(self) -> str:
-        return f"{self._plugin_unique_id.to_string()}-view"
+    
 
     @property
     def plugin_data_output(self) -> Output:

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -451,7 +451,7 @@ class WebvizPluginABC(abc.ABC):
         plugin_deprecation_warnings: Optional[List[str]] = None,
         argument_deprecation_warnings: Optional[List[str]] = None,
     ) -> List[Component]:
-        """This function returns plugin layour placed within a WebvizPluginWrapper
+        """This function returns plugin layout placed within a WebvizPluginWrapper
         component, which contains a settings drawer with useful buttons like fullscreen
         and screenshot of plugin content. Additional buttons as plugin author contact
         information, download of data, guided tour, issue feedback link, etc. will appear

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -497,7 +497,6 @@ class WebvizPluginABC(abc.ABC):
                         "id": self._legacy_plugin_view_id,
                         "group": "",
                         "name": "",
-                        # pylint: disable=protected-access
                         "showDownload": self._add_download_button,
                     }
                 ],

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -323,8 +323,6 @@ class WebvizPluginABC(abc.ABC):
 
         return settings
 
-    
-
     @property
     def plugin_data_output(self) -> Output:
         self._add_download_button = True

--- a/webviz_config/_plugin_abc.py
+++ b/webviz_config/_plugin_abc.py
@@ -326,7 +326,7 @@ class WebvizPluginABC(abc.ABC):
         return f"plugin-wrapper-{self._plugin_unique_id}"
 
     @property
-    def _legacy_plugin_view_id(self)->str:
+    def _legacy_plugin_view_id(self) -> str:
         return f"{self._plugin_unique_id.to_string()}-view"
 
     @property

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 from dash import html
 

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -22,7 +22,6 @@ Useful on e.g. the front page for introducing a field or project.
 * **`title_position`:** Position of title (either `center`, `top` or `bottom`).
 """
 
-    TOOLBAR_BUTTONS: List[str] = []
 
     CSS_TITLE_POSITIONS: Dict[str, str] = {
         "top": "start",

--- a/webviz_config/generic_plugins/_banner_image.py
+++ b/webviz_config/generic_plugins/_banner_image.py
@@ -22,7 +22,6 @@ Useful on e.g. the front page for introducing a field or project.
 * **`title_position`:** Position of title (either `center`, `top` or `bottom`).
 """
 
-
     CSS_TITLE_POSITIONS: Dict[str, str] = {
         "top": "start",
         "center": "center",

--- a/webviz_config/webviz_plugin_subclasses/_views.py
+++ b/webviz_config/webviz_plugin_subclasses/_views.py
@@ -661,7 +661,6 @@ class ViewABC(LayoutBaseABC):
     def outer_layout(self) -> Type[Component]:
         return wcc.WebvizView(
             id=str(self.get_unique_id()),
-            showDownload=self._add_download_button,
             children=self.inner_layout(),
         )
 


### PR DESCRIPTION
Download button not appearing for old plugin layout implementations.

- Fix breaking change
- Remove usage of unused prop from https://github.com/equinor/webviz-core-components/pull/232
- Ensure download button appearing and download callback being called for old layout implementation

----

Dependent on https://github.com/equinor/webviz-core-components/pull/232
