### PR TITLE
Improved `callback_typecheck` decorator, moved it and added test

### DIFF
--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -1,7 +1,12 @@
-from typing import TypedDict
-from typing import Dict, List, Optional, TypedDict, _TypedDictMeta, Union  # type: ignore[attr-defined]
-from webviz_config.utils import callback_typecheck, ConversionError
+from typing import (
+    Dict,
+    List,
+    Optional,
+    TypedDict,
+    Union,
+)
 from enum import Enum
+from webviz_config.utils import callback_typecheck, ConversionError
 
 
 def test_callback_typecheck() -> None:
@@ -18,7 +23,7 @@ def test_callback_typecheck() -> None:
     ############################################################
 
     def expect_none(arg: None) -> None:
-        assert arg == None
+        assert arg is None
 
     callback_typecheck(expect_none)(None)
 
@@ -34,9 +39,11 @@ def test_callback_typecheck() -> None:
     def expect_typed_dict(arg: MyTypedDict) -> None:
         types = [type(value) for value in arg.values()]
         assert (
-            type(arg) is dict
-            and set(arg.keys()) == set(MyTypedDict.__annotations__.keys())
-            and set(types) == set(MyTypedDict.__annotations__.values())
+            isinstance(arg, dict)
+            and set(arg.keys())
+            == set(MyTypedDict.__annotations__.keys())  # pylint: disable=no-member
+            and set(types)
+            == set(MyTypedDict.__annotations__.values())  # pylint: disable=no-member
         )
 
     callback_typecheck(expect_typed_dict)({"name": "Name", "year": 1990})
@@ -47,7 +54,7 @@ def test_callback_typecheck() -> None:
         assert False
     except ConversionError:
         pass
-    except Exception as e:
+    except Exception:  # pylint: disable=broad-except
         assert False
 
     ############################################################
@@ -55,11 +62,13 @@ def test_callback_typecheck() -> None:
     def expect_deep_typed_dict(arg: DeepTypedDict) -> None:
         types = [type(value) for value in arg.values()]
         assert (
-            type(arg) is dict
-            and set(arg.keys()) == set(DeepTypedDict.__annotations__.keys())
+            isinstance(arg, dict)
+            and set(arg.keys())
+            == set(DeepTypedDict.__annotations__.keys())  # pylint: disable=no-member
             # NOTE: A `TypedDict` is a `dict` at runtime
             and set(types) == set([dict])
-            and set(arg["value"].keys()) == set(MyTypedDict.__annotations__.keys())
+            and set(arg["value"].keys())
+            == set(MyTypedDict.__annotations__.keys())  # pylint: disable=no-member
         )
 
     callback_typecheck(expect_deep_typed_dict)(
@@ -106,7 +115,7 @@ def test_callback_typecheck() -> None:
     ############################################################
 
     def expect_optional(arg: Optional[str]) -> None:
-        assert arg == None or type(arg) == str
+        assert arg is None or isinstance(arg, str)
 
     callback_typecheck(expect_optional)(None)
     callback_typecheck(expect_optional)("string")
@@ -116,8 +125,8 @@ def test_callback_typecheck() -> None:
     def expect_union(arg: Union[str, int]) -> Union[str, int]:
         return arg
 
-    assert type(callback_typecheck(expect_union)("1")) == str
-    assert type(callback_typecheck(expect_union)(1)) == int
-    assert type(callback_typecheck(expect_union)(1.5)) == str
+    assert isinstance(callback_typecheck(expect_union)("1"), str)
+    assert isinstance(callback_typecheck(expect_union)(1), int)
+    assert isinstance(callback_typecheck(expect_union)(1.5), str)
 
     ############################################################

--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -1,0 +1,123 @@
+from typing import TypedDict
+from typing import Dict, List, Optional, TypedDict, _TypedDictMeta, Union  # type: ignore[attr-defined]
+from webviz_config.utils import callback_typecheck, ConversionError
+from enum import Enum
+
+
+def test_callback_typecheck() -> None:
+    class MyEnum(str, Enum):
+        VALUE_1 = "value-1"
+
+    class MyTypedDict(TypedDict):
+        name: str
+        year: int
+
+    class DeepTypedDict(TypedDict):
+        value: MyTypedDict
+
+    ############################################################
+
+    def expect_none(arg: None) -> None:
+        assert arg == None
+
+    callback_typecheck(expect_none)(None)
+
+    ############################################################
+
+    def expect_enum(arg: MyEnum) -> None:
+        assert isinstance(arg, MyEnum)
+
+    callback_typecheck(expect_enum)("value-1")
+
+    ############################################################
+
+    def expect_typed_dict(arg: MyTypedDict) -> None:
+        types = [type(value) for value in arg.values()]
+        assert (
+            type(arg) is dict
+            and set(arg.keys()) == set(MyTypedDict.__annotations__.keys())
+            and set(types) == set(MyTypedDict.__annotations__.values())
+        )
+
+    callback_typecheck(expect_typed_dict)({"name": "Name", "year": 1990})
+
+    # If any invalid key is given to a `TypedDict`, assert that a `ConversionError` is raised
+    try:
+        callback_typecheck(expect_typed_dict)({"name": "Name", "year2": 1990})
+        assert False
+    except ConversionError:
+        pass
+    except Exception as e:
+        assert False
+
+    ############################################################
+
+    def expect_deep_typed_dict(arg: DeepTypedDict) -> None:
+        types = [type(value) for value in arg.values()]
+        assert (
+            type(arg) is dict
+            and set(arg.keys()) == set(DeepTypedDict.__annotations__.keys())
+            # NOTE: A `TypedDict` is a `dict` at runtime
+            and set(types) == set([dict])
+            and set(arg["value"].keys()) == set(MyTypedDict.__annotations__.keys())
+        )
+
+    callback_typecheck(expect_deep_typed_dict)(
+        {"value": {"name": "Name", "year": 1990}}
+    )
+
+    ############################################################
+
+    def expect_int(arg: int) -> None:
+        assert isinstance(arg, int)
+
+    callback_typecheck(expect_int)("1")
+
+    ############################################################
+
+    def expect_float(arg: float) -> None:
+        assert isinstance(arg, float)
+
+    callback_typecheck(expect_float)("1.5")
+
+    ############################################################
+
+    def expect_str(arg: str) -> None:
+        assert isinstance(arg, str)
+
+    callback_typecheck(expect_str)(1)
+
+    ############################################################
+
+    def expect_list(arg: List[str]) -> None:
+        assert isinstance(arg, list)
+
+    callback_typecheck(expect_list)([1, 2, 3])
+
+    ############################################################
+
+    def expect_dict(arg: Dict[str, int]) -> None:
+        assert isinstance(arg, dict)
+        assert isinstance(list(arg.values())[0], int)
+        assert isinstance(list(arg.keys())[0], str)
+
+    callback_typecheck(expect_dict)({"1": 1})
+
+    ############################################################
+
+    def expect_optional(arg: Optional[str]) -> None:
+        assert arg == None or type(arg) == str
+
+    callback_typecheck(expect_optional)(None)
+    callback_typecheck(expect_optional)("string")
+
+    ############################################################
+
+    def expect_union(arg: Union[str, int]) -> Union[str, int]:
+        return arg
+
+    assert type(callback_typecheck(expect_union)("1")) == str
+    assert type(callback_typecheck(expect_union)(1)) == int
+    assert type(callback_typecheck(expect_union)(1.5)) == str
+
+    ############################################################

--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -100,6 +100,7 @@ def test_callback_typecheck() -> None:
 
     def expect_list(arg: List[str]) -> None:
         assert isinstance(arg, list)
+        assert isinstance(arg[0], str)
 
     callback_typecheck(expect_list)([1, 2, 3])
 
@@ -114,11 +115,11 @@ def test_callback_typecheck() -> None:
 
     ############################################################
 
-    def expect_optional(arg: Optional[str]) -> None:
-        assert arg is None or isinstance(arg, str)
+    def expect_optional(arg: Optional[str]) -> Optional[str]:
+        return arg
 
-    callback_typecheck(expect_optional)(None)
-    callback_typecheck(expect_optional)("string")
+    assert callback_typecheck(expect_optional)(None) is None
+    assert isinstance(callback_typecheck(expect_optional)("string"), str)
 
     ############################################################
 

--- a/webviz_config/generic_plugins/_example_wlf_plugin/_shared_settings/_shared_settings.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin/_shared_settings/_shared_settings.py
@@ -52,7 +52,7 @@ class SharedSettingsGroup(SettingsGroupABC):
                                 "value": 3,
                             },
                         ],
-                        value="2",
+                        value=2,
                     ),
                 ]
             )

--- a/webviz_config/generic_plugins/_example_wlf_plugin/_views/_plot/_view.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin/_views/_plot/_view.py
@@ -16,10 +16,8 @@ from webviz_config.webviz_plugin_subclasses import (
     ViewABC,
     ViewElementABC,
     SettingsGroupABC,
-    callback_typecheck,
 )
-
-from webviz_config.utils import StrEnum
+from webviz_config.utils import callback_typecheck, StrEnum
 
 from webviz_config.generic_plugins._example_wlf_plugin._shared_view_elements import (
     TextViewElement,

--- a/webviz_config/generic_plugins/_example_wlf_plugin/_views/_table/_view.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin/_views/_table/_view.py
@@ -10,14 +10,13 @@ import pandas as pd
 
 import webviz_core_components as wcc
 
-from webviz_config.utils import StrEnum
+from webviz_config.utils import callback_typecheck, StrEnum
 from webviz_config import WebvizPluginABC, EncodedFile
 
 from webviz_config.webviz_plugin_subclasses import (
     ViewABC,
     ViewElementABC,
     SettingsGroupABC,
-    callback_typecheck,
 )
 
 from webviz_config.generic_plugins._example_wlf_plugin._shared_view_elements import (

--- a/webviz_config/utils/__init__.py
+++ b/webviz_config/utils/__init__.py
@@ -6,3 +6,4 @@ from ._deprecate_webviz_settings_attribute_in_dash_app import (
     deprecate_webviz_settings_attribute_in_dash_app,
 )
 from ._str_enum import StrEnum
+from ._callback_typecheck import callback_typecheck, ConversionError

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -1,7 +1,6 @@
 # pylint: disable=line-too-long
-from typing import Any, Callable, get_origin, TypeVar
+from typing import Any, Callable, get_origin, _TypedDictMeta, TypeVar, Union  # type: ignore[attr-defined]
 import inspect
-from enum import Enum
 
 T = TypeVar("T")
 
@@ -14,14 +13,32 @@ def convert(arg: Any, convert_to: T) -> T:
     # pylint: disable=too-many-return-statements
     additional_error_message: str = ""
     try:
-        if inspect.isclass(convert_to) and issubclass(convert_to, Enum):
-            return convert_to(arg)  # type: ignore[return-value]
-        if convert_to is int:
-            return int(arg)  # type: ignore[return-value]
-        if convert_to is float:
-            return float(arg)  # type: ignore[return-value]
-        if convert_to is str:
-            return str(arg)  # type: ignore[return-value]
+        if convert_to is None and arg is None:
+            return None
+        if inspect.isclass(convert_to) and not type(convert_to) is _TypedDictMeta:
+            return convert_to(arg)
+        if (
+            type(convert_to) is _TypedDictMeta
+            and "__annotations__" in dir(convert_to)
+            and isinstance(arg, dict)
+        ):
+            new_dict = convert_to()
+            for key, value in arg.items():
+                if key in list(convert_to.__annotations__.keys()):
+                    new_dict[key] = convert(value, convert_to.__annotations__[key])
+                else:
+                    raise Exception(
+                        f"""
+                        Key '{key}' not allowed in '{convert_to}'.\n
+                        Allowed keys are: {', '.join(list(convert_to.__annotations__.keys()))}
+                        """
+                    )
+
+            if not convert_to.__total__ or len(new_dict.keys()) == len(
+                convert_to.__annotations__.keys()
+            ):
+                return new_dict
+
         if convert_to is list and isinstance(arg, list):
             return arg  # type: ignore[return-value]
         if get_origin(convert_to) is list and isinstance(arg, list):
@@ -37,6 +54,16 @@ def convert(arg: Any, convert_to: T) -> T:
                     )
                     for key, value in arg.items()
                 }
+        if get_origin(convert_to) is Union:
+            if "__args__" in dir(convert_to):
+                for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
+                    if isinstance(arg, convert_type):
+                        return arg
+                for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
+                    try:
+                        return convert(arg, convert_type)
+                    except ConversionError:
+                        pass
 
     # pylint: disable=broad-except
     except Exception as exception:

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -10,15 +10,15 @@ class ConversionError(Exception):
 
 
 def convert(arg: Any, convert_to: T) -> T:
-    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-return-statements, too-many-branches
     additional_error_message: str = ""
     try:
         if convert_to is None and arg is None:
             return None
-        if inspect.isclass(convert_to) and not type(convert_to) is _TypedDictMeta:
+        if inspect.isclass(convert_to) and not isinstance(convert_to, _TypedDictMeta):
             return convert_to(arg)
         if (
-            type(convert_to) is _TypedDictMeta
+            isinstance(convert_to, _TypedDictMeta)
             and "__annotations__" in dir(convert_to)
             and isinstance(arg, dict)
         ):

--- a/webviz_config/webviz_plugin_subclasses/__init__.py
+++ b/webviz_config/webviz_plugin_subclasses/__init__.py
@@ -2,4 +2,3 @@ from ._settings_group_abc import SettingsGroupABC
 from ._views import ViewABC, ViewElementABC, ViewLayoutElement, LayoutElementType
 from ._layout_base_abc import LayoutBaseABC
 from ._layout_unique_id import LayoutUniqueId
-from ._callback_typecheck import callback_typecheck


### PR DESCRIPTION
Improved `callback_typecheck` decorator (e.g. added conversion support of `TypedDict` and `Union`). Added a test for many different conversions and moved the decorator file to `utils`.

---

Closes #625.
Closes #622.