### PR TITLE
Added try except statement around `isinstance` check to avoid exception

### DIFF
--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -131,3 +131,12 @@ def test_callback_typecheck() -> None:
     assert isinstance(callback_typecheck(expect_union)(1.5), str)
 
     ############################################################
+
+    def expect_union_list(arg: Union[List[str], str]) -> Union[List[str], str]:
+        return arg
+
+    assert isinstance(callback_typecheck(expect_union_list)(["1", "2"]), list)
+    assert isinstance(callback_typecheck(expect_union_list)(["1", "2"])[0], str)
+    assert isinstance(callback_typecheck(expect_union_list)("1"), str)
+
+    ############################################################

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -60,8 +60,7 @@ def convert(arg: Any, convert_to: T) -> T:
                     try:
                         if isinstance(arg, convert_type):
                             return arg
-                    # pylint: disable=broad-except
-                    except Exception:
+                    except TypeError:
                         pass
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
                     try:

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -60,8 +60,8 @@ def convert(arg: Any, convert_to: T) -> T:
                     try:
                         if isinstance(arg, convert_type):
                             return arg
-                    # pylint: disable=bare-except
-                    except:
+                    # pylint: disable=broad-except
+                    except Exception:
                         pass
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
                     try:

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -10,7 +10,7 @@ class ConversionError(Exception):
 
 
 def convert(arg: Any, convert_to: T) -> T:
-    # pylint: disable=too-many-return-statements, too-many-branches
+    # pylint: disable=too-many-return-statements, too-many-branches, too-many-nested-blocks
     additional_error_message: str = ""
     try:
         if convert_to is None and arg is None:

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -57,8 +57,11 @@ def convert(arg: Any, convert_to: T) -> T:
         if get_origin(convert_to) is Union:
             if "__args__" in dir(convert_to):
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
-                    if isinstance(arg, convert_type):
-                        return arg
+                    try:
+                        if isinstance(arg, convert_type):
+                            return arg
+                    except:
+                        pass
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]
                     try:
                         return convert(arg, convert_type)

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -60,6 +60,7 @@ def convert(arg: Any, convert_to: T) -> T:
                     try:
                         if isinstance(arg, convert_type):
                             return arg
+                    # pylint: disable=broad-except
                     except:
                         pass
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]

--- a/webviz_config/utils/_callback_typecheck.py
+++ b/webviz_config/utils/_callback_typecheck.py
@@ -60,7 +60,7 @@ def convert(arg: Any, convert_to: T) -> T:
                     try:
                         if isinstance(arg, convert_type):
                             return arg
-                    # pylint: disable=broad-except
+                    # pylint: disable=bare-except
                     except:
                         pass
                 for convert_type in convert_to.__args__:  # type: ignore[attr-defined]


### PR DESCRIPTION
When converting a `Union` a first test was implemented before any conversion if an argument was already of the desired type. This test was implement by using the `isinstance` function. However, this check does not work with e.g. `typing.List` or `typing.Dict` types.