### PR TITLE
Add line color as view element setting for Plot in WLF example plugin

### DIFF
--- a/webviz_config/generic_plugins/_example_wlf_plugin/_plugin.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin/_plugin.py
@@ -4,7 +4,12 @@ from dash import Input
 
 from webviz_config import WebvizPluginABC
 from webviz_config.utils import StrEnum
-from ._views._plot import PlotView, PlotViewElement, PlotViewSettingsGroup
+from ._views._plot import (
+    PlotView,
+    PlotViewElement,
+    PlotViewSettingsGroup,
+    PlotViewElementSettingsGroup,
+)
 from ._views._table import TableView, TableViewElement, TableViewSettingsGroup
 from ._shared_view_elements import TextViewElement
 from ._shared_settings import SharedSettingsGroup
@@ -98,6 +103,13 @@ class ExampleWlfPlugin(WebvizPluginABC):
                 .settings_group(PlotView.Ids.PLOT_SETTINGS)
                 .component_unique_id(PlotViewSettingsGroup.Ids.COORDINATES_SELECTOR),
                 "content": "...and here you can swap the axes.",
+            },
+            {
+                "id": self.view(ExampleWlfPlugin.Ids.PLOT_VIEW)
+                .view_element(PlotView.Ids.PLOT)
+                .settings_group(PlotViewElement.Ids.PLOT_SETTINGS)
+                .component_unique_id(PlotViewElementSettingsGroup.Ids.COLOR_SELECTOR),
+                "content": "You can change here which color you prefer.",
             },
             {
                 "id": self.view(ExampleWlfPlugin.Ids.TABLE_VIEW)

--- a/webviz_config/generic_plugins/_example_wlf_plugin/_views/_plot/__init__.py
+++ b/webviz_config/generic_plugins/_example_wlf_plugin/_views/_plot/__init__.py
@@ -1,1 +1,7 @@
-from ._view import PlotView, PlotViewElement, PlotViewSettingsGroup, Kindness
+from ._view import (
+    PlotView,
+    PlotViewElement,
+    PlotViewSettingsGroup,
+    PlotViewElementSettingsGroup,
+    Kindness,
+)


### PR DESCRIPTION
Add color selection as view element settings for Plot. Add the settings group to tour steps.

To illustrate usage of view element setting and tour step dialog control.

Closes: https://github.com/equinor/webviz-config/issues/628