### PR TITLE
Implemented new `homepage` option in `menu > options` in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#594](https://github.com/equinor/webviz-config/pull/594) - Added early testing of graphical user interface (GUI) for editing and creating Webviz configuration files. Run `webviz editor` to start the GUI.
 - [#599](https://github.com/equinor/webviz-config/pull/599) - Implemented new Webviz Layout Framework (WLF).
+- [#631](https://github.com/equinor/webviz-config/pull/631) - Added `homepage` option to `menu` options in config file to define which page should be shown first when opening a Webviz app.
 
 ### Fixed
 - [#588](https://github.com/equinor/webviz-config/pull/588) - Added compatibility with upstream dependency `bleach >= 5`.

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -541,7 +541,7 @@ class ConfigParser:
                         f"{terminal_colors.RED}{terminal_colors.BOLD}"
                         "Invalid option for options > menu > homepage: "
                         f"{self.configuration['options']['menu']['homepage']}. "
-                        f"Please select from the existing pages:\n{', '.join(self._page_titles)}"
+                        f"Please check your config file and use the name of an existing page."
                         f"{terminal_colors.END}"
                     )
                 else:

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -240,6 +240,7 @@ class ConfigParser:
             ).with_traceback(sys.exc_info()[2])
 
         self._config_folder = pathlib.Path(yaml_file).parent
+        self._page_titles: List[str] = []
         self._page_ids: List[str] = []
         self._assets: set = set()
         self._plugin_metadata: Dict[str, dict] = {}
@@ -394,8 +395,8 @@ class ConfigParser:
                     }
                 )
             elif "page" in item or "title" in item:
-
                 page_title = item["page"] if "page" in item else item["title"]
+                self._page_titles.append(page_title)
                 if "id" not in item:
                     item["id"] = self._generate_page_id(page_title)
                 elif item["id"] in self._page_ids:
@@ -519,6 +520,36 @@ class ConfigParser:
                         "Please select a boolean value: True, False"
                         f"{terminal_colors.END}"
                     )
+
+                if "homepage" not in self.configuration["options"]["menu"]:
+                    self.configuration["options"]["menu"]["homepage"] = None
+                elif not isinstance(
+                    self.configuration["options"]["menu"]["homepage"], str
+                ):
+                    raise ParserError(
+                        f"{terminal_colors.RED}{terminal_colors.BOLD}"
+                        "Invalid option for options > menu > homepage: "
+                        f"{self.configuration['options']['menu']['homepage']}. "
+                        "Please select a valid string value"
+                        f"{terminal_colors.END}"
+                    )
+                elif (
+                    self.configuration["options"]["menu"]["homepage"]
+                    not in self._page_titles
+                ):
+                    raise ParserError(
+                        f"{terminal_colors.RED}{terminal_colors.BOLD}"
+                        "Invalid option for options > menu > homepage: "
+                        f"{self.configuration['options']['menu']['homepage']}. "
+                        f"Please select from the existing pages:\n{', '.join(self._page_titles)}"
+                        f"{terminal_colors.END}"
+                    )
+                else:
+                    self.configuration["options"]["menu"]["homepage"] = self._page_ids[
+                        self._page_titles.index(
+                            self.configuration["options"]["menu"]["homepage"]
+                        )
+                    ]
 
                 if "initially_collapsed" not in self.configuration["options"]["menu"]:
                     self.configuration["options"]["menu"]["initially_collapsed"] = False

--- a/webviz_config/_docs/_create_schema.py
+++ b/webviz_config/_docs/_create_schema.py
@@ -42,7 +42,10 @@ JSON_SCHEMA = {
                         "type": "boolean",
                     },
                     "homepage": {
-                        "description": "Set a custom page as homepage to which the user returns when clicking on the logo. Use the page's title.",
+                        "description": """
+                        Set a custom page as homepage to which the user returns when clicking on the logo. 
+                        Use the page's title.
+                        """,
                         "type": "string",
                     },
                 },

--- a/webviz_config/_docs/_create_schema.py
+++ b/webviz_config/_docs/_create_schema.py
@@ -41,6 +41,10 @@ JSON_SCHEMA = {
                         "description": "State if all groups in menu shall initially be collapsed",
                         "type": "boolean",
                     },
+                    "homepage": {
+                        "description": "Set a custom page as homepage to which the user returns when clicking on the logo. Use the page's title.",
+                        "type": "string",
+                    },
                 },
                 "additionalProperties": False,
             },

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -157,7 +157,7 @@ else:
                         initiallyCollapsed={{options.menu.initially_collapsed}},
                         navigationItems={{navigation_items}},
                         {% if options.menu.homepage %}
-                        homepageUrl={{options.menu.homepage}}
+                        homepageUrl="{{options.menu.homepage}}"
                         {% endif %}
                     ),
                     wcc.WebvizSettingsDrawer(

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -156,6 +156,9 @@ else:
                         initiallyPinned={{options.menu.initially_pinned}},
                         initiallyCollapsed={{options.menu.initially_collapsed}},
                         navigationItems={{navigation_items}},
+                        {% if options.menu.homepage %}
+                        homepageUrl={{options.menu.homepage}}
+                        {% endif %}
                     ),
                     wcc.WebvizSettingsDrawer(
                         id="settings-drawer",
@@ -180,21 +183,17 @@ oauth2 = webviz_config.Oauth2(app.server) if use_oauth2 else None
 @callback(
     Output("plugins-wrapper", "children"), 
     Output("settings-drawer", "children"), 
-    Input("main-menu", "url"), 
     Input("location", "pathname")
 )
-def update_page(url, pathname):
+def update_page(pathname):
     ctx = callback_context
     if ctx.triggered:
-        if ctx.triggered[0]["prop_id"].split('.')[0] == "main-menu":
-            pathname = url.replace("/", "") if url is not None else ""
+        if pathname is not None:
+            pathname = pathname.replace("/", "")
         else:
-            if pathname is not None:
-                pathname = pathname.replace("/", "")
-            else:
-                pathname = ""
-        if not pathname:
-            pathname = next(iter(page_plugins)) 
+            pathname = ""
+    if not pathname:
+        pathname = next(iter(page_plugins)) 
     return page_plugins.get(pathname, ["Oooppss... Page not found."]), page_settings.get(pathname, [])
 
 {{ "WEBVIZ_ASSETS.directly_host_assets(app)" if not portable else ""}}


### PR DESCRIPTION
Now, it is possible to select which page to be shown first when opening a Webviz application via `options > menu > homepage` in the config file.

Dependent on https://github.com/equinor/webviz-core-components/pull/264.