### PR TITLE
Improved typechecking, especially for `Union`

### DIFF
--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -1,15 +1,10 @@
-from typing import (
-    Dict,
-    List,
-    Optional,
-    TypedDict,
-    Union,
-)
+from typing import Dict, List, Optional, TypedDict, Union
 from enum import Enum
 from webviz_config.utils import callback_typecheck, ConversionError
 
 
 def test_callback_typecheck() -> None:
+
     # pylint: disable=too-many-locals, too-many-statements
     class MyEnum(str, Enum):
         VALUE_1 = "value-1"
@@ -160,3 +155,16 @@ def test_callback_typecheck() -> None:
         pass
     except Exception:  # pylint: disable=broad-except
         assert False
+
+    ############################################################
+
+    def expect_union_string_list(
+        arg: Union[str, List[str], Dict[str, str], Optional[int]]
+    ) -> Union[str, List[str], Dict[str, str], Optional[int]]:
+        return arg
+
+    assert callback_typecheck(expect_union_string_list)(["1", "2"]) == ["1", "2"]
+    assert callback_typecheck(expect_union_string_list)("1") == "1"
+    assert callback_typecheck(expect_union_string_list)({"1": "1"}) == {"1": "1"}
+    assert callback_typecheck(expect_union_string_list)(None) == None
+    assert callback_typecheck(expect_union_string_list)(1) == 1

--- a/tests/test_callback_typecheck.py
+++ b/tests/test_callback_typecheck.py
@@ -166,5 +166,5 @@ def test_callback_typecheck() -> None:
     assert callback_typecheck(expect_union_string_list)(["1", "2"]) == ["1", "2"]
     assert callback_typecheck(expect_union_string_list)("1") == "1"
     assert callback_typecheck(expect_union_string_list)({"1": "1"}) == {"1": "1"}
-    assert callback_typecheck(expect_union_string_list)(None) == None
+    assert callback_typecheck(expect_union_string_list)(None) is None
     assert callback_typecheck(expect_union_string_list)(1) == 1


### PR DESCRIPTION
Introduced a new custom `_isinstance` function in `_callback_typecheck.py` in order to check if a variable already complies with the expected type. This does especially improve the type checking of `Union` types.