### PR TITLE
Fixed issue when `options` not given in config file

### DIFF
--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -587,4 +587,5 @@ class ConfigParser:
                 "initially_pinned": False,
                 "initially_collapsed": False,
                 "show_logo": True,
+                "homepage": None,
             }


### PR DESCRIPTION
Webviz would not build when no `options` were given in config file. This was due to `homepage` property missing in fallback `options` dictionary.