### PR TITLE
Regression fix: Show filters in TablePlotter when using `lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- [#655](https://github.com/equinor/webviz-config/pull/655) - Regression fix: Show filters in `TablePlotter` when using `lock` argument.
 
 ### Changed
 - [#648](https://github.com/equinor/webviz-config/pull/648) - Allow `blob:` in `script-src` CSP in order to enable web worker usage in Dash components.

--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -77,7 +77,8 @@ layout:
           x: Well
           y: Initial reservoir pressure (bar)
           size: Average permeability (D)
-          facet_col: Segment
+        filter_cols:
+         - Well
         contact_person:
           name: Kari Nordmann
           phone: 12345678

--- a/tests/test_table_plotter.py
+++ b/tests/test_table_plotter.py
@@ -71,12 +71,6 @@ def test_table_plotter_filter(dash_duo: DashComposite) -> None:
     plot_dd = dash_duo.find_element("#" + page.uuid("plottype"))
     assert plot_dd.text == "scatter"
 
-    # Checking that only the relevant options are shown
-    for plot_option in page.plot_args.keys():
-        plot_option_dd = dash_duo.find_element("#" + page.uuid(f"div-{plot_option}"))
-        if plot_option not in page.plots["scatter"]:
-            assert "display: none;" in plot_option_dd.get_attribute("style")
-
     # Checking that options are initialized correctly
     for option in ["x", "y"]:
         plot_option_dd = dash_duo.find_element("#" + page.uuid(f"dropdown-{option}"))
@@ -110,7 +104,3 @@ def test_initialized_table_plotter(dash_duo: DashComposite) -> None:
     # Checking that plot options are defined
     assert page.plot_options == plot_options
     assert page.lock
-
-    # Checking that the selectors are hidden
-    selector_row = dash_duo.find_element("#" + page.uuid("selector-row"))
-    assert "display: none;" in selector_row.get_attribute("style")

--- a/webviz_config/generic_plugins/_table_plotter.py
+++ b/webviz_config/generic_plugins/_table_plotter.py
@@ -374,19 +374,23 @@ If feature is requested, the data could also come from a database.
 
     @property
     def layout(self) -> html.Div:
+        plot_options_style: dict = {"display": "none"} if self.lock else {}
         return html.Div(
             children=[
                 wcc.FlexBox(
                     children=[
                         html.Div(
                             id=self.uuid("selector-row"),
-                            style={"display": "none"}
-                            if self.lock
-                            else {"width": "15%"},
                             children=[
-                                self.plot_option_layout(),
+                                html.Div(
+                                    style=plot_options_style,
+                                    children=self.plot_option_layout(),
+                                ),
                                 self.filter_layout(),
-                                self.axis_layout(),
+                                html.Div(
+                                    style=plot_options_style,
+                                    children=self.axis_layout(),
+                                ),
                             ],
                         ),
                         wcc.Graph(


### PR DESCRIPTION
Regression fix of https://github.com/equinor/webviz-config/pull/635

Tableplotter plugins using the `lock` arguments should still display any specified filters.