### PR TITLE
Do not silently refresh tokens

### DIFF
--- a/webviz_config/_oauth2.py
+++ b/webviz_config/_oauth2.py
@@ -151,6 +151,10 @@ class Oauth2:
                 # Access token has expired
                 print("Access token has expired, trying to refresh.")
                 try:
+                    raise Exception(
+                        "Disable refreshing, it is broken and a security risk"
+                    )
+                    # pylint: disable=W0101
                     access_token, expiration_date = self.refresh_token_if_possible()
                     flask.session["access_token"] = access_token
                     flask.session["expiration_date"] = expiration_date


### PR DESCRIPTION
this is a hotfix for a security issue where silent token refresh asigns the wrong tokens to end users. A significant drawback of this hotfix is that it now forces an interactive token-retrieval every time tokens expire, which will cause the user to lose work in progress (unless state is set to persist)

*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

---

### Contributor checklist

- [x ] :tada: This PR closes #662.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
