### PR TITLE
fix: use a pure path rather than real path when defining config path …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
+- [#548](https://github.com/equinor/webviz-config/pull/548) - Regression fix: Allow deploying portable builds made in Windows to run on posix systems and vice versa
 - [#655](https://github.com/equinor/webviz-config/pull/655) - Regression fix: Show filters in `TablePlotter` when using `lock` argument.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
-- [#548](https://github.com/equinor/webviz-config/pull/548) - Regression fix: Allow deploying portable builds made in Windows to run on posix systems and vice versa
 - [#655](https://github.com/equinor/webviz-config/pull/655) - Regression fix: Show filters in `TablePlotter` when using `lock` argument.
 
 ### Changed

--- a/webviz_config/_config_parser.py
+++ b/webviz_config/_config_parser.py
@@ -195,7 +195,9 @@ def _call_signature(
         special_args += "webviz_settings=webviz_settings, "
 
     return (
-        f"{plugin_name}({special_args}**{kwargs})",
+        f"{plugin_name}({special_args}**{kwargs})".replace(
+            "WindowsPath", "Path"
+        ).replace("PosixPath", "Path"),
         (
             f"plugin_layout(contact_person={contact_person}"
             f", plugin_deprecation_warnings={plugin_deprecation_warnings}"

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -27,7 +27,9 @@ def write_script(
     configuration.update(
         {
             "author": getpass.getuser(),
-            "config_folder": repr(args.yaml_file.resolve().parent),
+            "config_folder": repr(
+                pathlib.PurePath(args.yaml_file.resolve().parent.as_posix())
+            ),
             "current_date": datetime.date.today().strftime("%Y-%m-%d"),
             "debug": args.debug,
             "loglevel": args.loglevel,

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -27,9 +27,7 @@ def write_script(
     configuration.update(
         {
             "author": getpass.getuser(),
-            "config_folder": repr(
-                pathlib.PurePath(args.yaml_file.resolve().parent.as_posix())
-            ),
+            "config_folder": repr(args.yaml_file.resolve().parent),
             "current_date": datetime.date.today().strftime("%Y-%m-%d"),
             "debug": args.debug,
             "loglevel": args.loglevel,

--- a/webviz_config/_write_script.py
+++ b/webviz_config/_write_script.py
@@ -27,7 +27,7 @@ def write_script(
     configuration.update(
         {
             "author": getpass.getuser(),
-            "config_folder": repr(args.yaml_file.resolve().parent),
+            "config_folder": f"Path('{(args.yaml_file.resolve().parent.as_posix())}')",
             "current_date": datetime.date.today().strftime("%Y-%m-%d"),
             "debug": args.debug,
             "loglevel": args.loglevel,

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -4,7 +4,7 @@
 import logging
 import logging.config
 import datetime
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path
 
 import dash
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -4,7 +4,7 @@
 import logging
 import logging.config
 import datetime
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PosixPath, WindowsPath
 
 import dash
 

--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -4,7 +4,7 @@
 import logging
 import logging.config
 import datetime
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import dash
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -10,7 +10,7 @@ import logging.config
 import os
 import threading
 import datetime
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path
 
 from uuid import uuid4
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -10,7 +10,7 @@ import logging.config
 import os
 import threading
 import datetime
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from uuid import uuid4
 

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -10,7 +10,7 @@ import logging.config
 import os
 import threading
 import datetime
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PosixPath, WindowsPath
 
 from uuid import uuid4
 


### PR DESCRIPTION
…in templates

real paths will throw if they are instantiated on the wrong system, which causes protable builds made in windows to fail when deploying in linux containers, e.g. on radix

*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

---

### Contributor checklist

- [x] :tada: This PR closes #548.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
