### PR TITLE
Fix JSONDecodeError to get CI running

### DIFF
--- a/webviz_config/_dockerize/_create_docker_setup.py
+++ b/webviz_config/_dockerize/_create_docker_setup.py
@@ -11,7 +11,7 @@ from ..plugins import PLUGIN_PROJECT_METADATA
 from ._pip_git_url import pip_git_url
 
 
-PYPI_URL_ROOT = "https://pypi.org/"
+PYPI_URL_ROOT = "https://pypi.org"
 
 
 def create_docker_setup(


### PR DESCRIPTION
Remove end slash from `PYPI_URL_ROOT` to avoid JSONDecodeError in `requests` due to double slashes

`PYPI_URL_ROOT = "https://pypi.org"`
`pypi_data = requests.get(f"{PYPI_URL_ROOT}/pypi/{dist_name}/json").json()`