### PR TITLE
Adapt to recent `get_logs()` return type

### DIFF
--- a/tests/test_create_themed_layout.py
+++ b/tests/test_create_themed_layout.py
@@ -147,4 +147,4 @@ def test_create_themed_layout_on_app(dash_duo):
         # test some values
         assert new_layout["colorway"] == specified_layout["colorway"]
         assert new_layout["xaxis"]["title"]["text"] == "Title"
-        assert dash_duo.get_logs() is None, "browser console should contain no error"
+        assert not dash_duo.get_logs(), "browser console should contain no error"

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -21,7 +21,7 @@ def test_data_table(dash_duo):
         page = _data_table.DataTable(app, code_file)
         app.layout = page.layout
         dash_duo.start_server(app)
-        assert dash_duo.get_logs() is None, "browser console should contain no error"
+        assert not dash_duo.get_logs(), "browser console should contain no error"
 
 
 def test_data_table_with_settings(dash_duo):
@@ -39,4 +39,4 @@ def test_data_table_with_settings(dash_duo):
         )
         app.layout = page.layout
         dash_duo.start_server(app)
-        assert dash_duo.get_logs() is None, "browser console should contain no error"
+        assert not dash_duo.get_logs(), "browser console should contain no error"

--- a/tests/test_portable.py
+++ b/tests/test_portable.py
@@ -24,4 +24,4 @@ def test_portable(dash_duo, tmp_path):
         "pivot-table",
     ]:
         dash_duo.wait_for_element(f".Menu__Page[href='/{page}']").click()
-    assert dash_duo.get_logs() is None, "browser console should contain no error"
+    assert not dash_duo.get_logs(), "browser console should contain no error"

--- a/tests/test_syntax_highlighter.py
+++ b/tests/test_syntax_highlighter.py
@@ -20,4 +20,4 @@ def test_syntax_highlighter(dash_duo):
         page = _syntax_highlighter.SyntaxHighlighter(app, code_file)
         app.layout = page.layout
         dash_duo.start_server(app)
-        assert dash_duo.get_logs() is None, "browser console should contain no error"
+        assert not dash_duo.get_logs(), "browser console should contain no error"


### PR DESCRIPTION
Similar to https://github.com/equinor/webviz-subsurface/pull/1265.

Closes #676.
