### PR TITLE
Set `react` version to `18.2.0`

### DIFF
--- a/webviz_config/templates/copy_data_template.py.jinja2
+++ b/webviz_config/templates/copy_data_template.py.jinja2
@@ -24,7 +24,7 @@ theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())
 theme.plotly_theme_layout_update({{ options.plotly_theme }})
 
-dash._dash_renderer._set_react_version("18.3.1")
+dash._dash_renderer._set_react_version("18.2.0")
 
 app = dash.Dash()
 app.config.suppress_callback_exceptions = True

--- a/webviz_config/templates/webviz_template.py.jinja2
+++ b/webviz_config/templates/webviz_template.py.jinja2
@@ -40,7 +40,7 @@ theme = webviz_config.WebvizConfigTheme("{{ theme_name }}")
 theme.from_json((Path(__file__).resolve().parent / "theme_settings.json").read_text())
 theme.plotly_theme_layout_update({{ options.plotly_theme }})
 
-_dash_renderer._set_react_version("18.3.1")
+_dash_renderer._set_react_version("18.2.0")
 
 app = Dash(
     name=__name__,


### PR DESCRIPTION
We have to pin `React` to version 18.2 since `Dash` is comparing the installed version with a list of supported versions. `18.2` is the newest one.

We are only pinning in `package-lock.json` as we are installing the package by using the `ci` command.