### PR TITLE
Using `azure-monitor-opentelemetry-exporter`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         "webviz-core-components>=0.6",
         "werkzeug>=2.0",
         "azure-monitor-opentelemetry-exporter>=1.0.0b41",
+        "azure-monitor-events-extension>=0.1.0",
         "opentelemetry-sdk>=1.27",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ setup(
         "webviz-core-components>=0.6",
         "werkzeug>=2.0",
         "azure-monitor-opentelemetry-exporter>=1.0.0b41",
-        "azure-monitor-events-extension>=0.1.0",
         "opentelemetry-sdk>=1.27",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ setup(
         "tqdm>=4.8",
         "webviz-core-components>=0.6",
         "werkzeug>=2.0",
-        "azure-monitor-opentelemetry>=1.8.7",
+        "azure-monitor-opentelemetry-exporter>=1.0.0b41",
+        "opentelemetry-sdk>=1.27",
     ],
     extras_require={
         "tests": TESTS_REQUIRES,

--- a/webviz_config/utils/_usage_analytics.py
+++ b/webviz_config/utils/_usage_analytics.py
@@ -88,7 +88,9 @@ def setup_usage_analytics() -> Optional[UsageAnalytics]:
         )
 
         logger_provider = LoggerProvider(resource=resource, shutdown_on_exit=True)
-        log_exporter = AzureMonitorLogExporter(connection_string=app_insights_connection_string)
+        log_exporter = AzureMonitorLogExporter(
+            connection_string=app_insights_connection_string
+        )
         logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
         set_logger_provider(logger_provider)
 

--- a/webviz_config/utils/_usage_analytics.py
+++ b/webviz_config/utils/_usage_analytics.py
@@ -1,11 +1,10 @@
-import atexit
+import logging
 import os
 import platform
 import pwd
 from importlib.metadata import entry_points, version
 from typing import Optional
 
-from azure.monitor.events.extension import track_event
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk.resources import Resource
@@ -13,7 +12,7 @@ from opentelemetry.sdk.resources import Resource
 # opentelemetry.sdk._logs is experimental, but official Microsoft package
 # azure-monitor-opentelemetry depends on them as well (a package we don't want
 # to use due to larger unncessary dependency tree in Komodo)
-from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 
@@ -24,18 +23,21 @@ _LOGGING_CONN_STRING_ENTRYPOINT_NAME = "webviz-azure-logging-connection-string"
 
 
 class UsageAnalytics:
-    def __init__(self, user_name: str) -> None:
+    def __init__(self, telemetry_logger: logging.Logger, user_name: str) -> None:
+        self._telemetry_logger = telemetry_logger
         self._user_name = user_name
 
     def log_plugin_usage(self, path_name: str, plugin_name: str) -> None:
-        track_event(
-            "PLUGIN_USAGE",
-            {
-                "wv_plugin_name": plugin_name,
-                "wv_user_name": self._user_name,
-                "wv_path_name": path_name,
-            },
-        )
+        log_msg = f"PLUGIN_USAGE - plugin_name={plugin_name}, user_name={self._user_name}, path_name={path_name}"
+        # print(f"log_plugin_usage(): {log_msg}")
+
+        extra = {
+            "wv_plugin_name": plugin_name,
+            "wv_user_name": self._user_name,
+            "wv_path_name": path_name,
+        }
+
+        self._telemetry_logger.info(log_msg, extra=extra)
 
 
 def setup_usage_analytics() -> Optional[UsageAnalytics]:
@@ -85,25 +87,25 @@ def setup_usage_analytics() -> Optional[UsageAnalytics]:
             }
         )
 
-        logger_provider = LoggerProvider(resource=resource)
-        logger_provider.add_log_record_processor(
-            BatchLogRecordProcessor(
-                AzureMonitorLogExporter(
-                    connection_string=app_insights_connection_string
-                )
-            )
-        )
+        logger_provider = LoggerProvider(resource=resource, shutdown_on_exit=True)
+        log_exporter = AzureMonitorLogExporter(connection_string=app_insights_connection_string)
+        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
         set_logger_provider(logger_provider)
 
-        # Ensure buffered log records are flushed before interpreter exit.
-        atexit.register(logger_provider.shutdown)
+        telemetry_py_logger = logging.getLogger("wv_telemetry_logger")
+        telemetry_py_logger.setLevel(logging.INFO)
+        telemetry_py_logger.propagate = False
+
+        handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+        telemetry_py_logger.addHandler(handler)
+
     except Exception as exc:  # pylint: disable=broad-except
         print(
             f"Failed to set up telemetry for usage analytics, proceeding without telemetry. Error: {exc}"
         )
         return None
 
-    return UsageAnalytics(user_name=username)
+    return UsageAnalytics(telemetry_logger=telemetry_py_logger, user_name=username)
 
 
 def _get_connection_string_from_entrypoint() -> Optional[str]:

--- a/webviz_config/utils/_usage_analytics.py
+++ b/webviz_config/utils/_usage_analytics.py
@@ -5,11 +5,16 @@ import pwd
 from importlib.metadata import entry_points, version
 from typing import Optional
 
-from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
-from opentelemetry import trace
+from azure.monitor.events.extension import track_event
+from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# opentelemetry.sdk._logs is experimental, but official Microsoft package
+# azure-monitor-opentelemetry depends on them as well (a package we don't want
+# to use due to larger unncessary dependency tree in Komodo)
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 
 # pylint: disable=line-too-long
@@ -19,20 +24,18 @@ _LOGGING_CONN_STRING_ENTRYPOINT_NAME = "webviz-azure-logging-connection-string"
 
 
 class UsageAnalytics:
-    def __init__(self, tracer: trace.Tracer, user_name: str) -> None:
-        self._tracer = tracer
+    def __init__(self, user_name: str) -> None:
         self._user_name = user_name
 
     def log_plugin_usage(self, path_name: str, plugin_name: str) -> None:
-        with self._tracer.start_as_current_span(
+        track_event(
             "PLUGIN_USAGE",
-            attributes={
+            {
                 "wv_plugin_name": plugin_name,
                 "wv_user_name": self._user_name,
                 "wv_path_name": path_name,
             },
-        ):
-            pass
+        )
 
 
 def setup_usage_analytics() -> Optional[UsageAnalytics]:
@@ -82,26 +85,25 @@ def setup_usage_analytics() -> Optional[UsageAnalytics]:
             }
         )
 
-        tracer_provider = TracerProvider(resource=resource)
-        tracer_provider.add_span_processor(
-            BatchSpanProcessor(
-                AzureMonitorTraceExporter(
+        logger_provider = LoggerProvider(resource=resource)
+        logger_provider.add_log_record_processor(
+            BatchLogRecordProcessor(
+                AzureMonitorLogExporter(
                     connection_string=app_insights_connection_string
                 )
             )
         )
-        trace.set_tracer_provider(tracer_provider)
+        set_logger_provider(logger_provider)
 
-        atexit.register(tracer_provider.shutdown)
-
-        tracer = trace.get_tracer("wv_telemetry")
+        # Ensure buffered log records are flushed before interpreter exit.
+        atexit.register(logger_provider.shutdown)
     except Exception as exc:  # pylint: disable=broad-except
         print(
             f"Failed to set up telemetry for usage analytics, proceeding without telemetry. Error: {exc}"
         )
         return None
 
-    return UsageAnalytics(tracer=tracer, user_name=username)
+    return UsageAnalytics(user_name=username)
 
 
 def _get_connection_string_from_entrypoint() -> Optional[str]:

--- a/webviz_config/utils/_usage_analytics.py
+++ b/webviz_config/utils/_usage_analytics.py
@@ -1,12 +1,16 @@
-import logging
+import atexit
 import os
 import platform
 import pwd
 from importlib.metadata import entry_points, version
 from typing import Optional
 
-from azure.monitor.opentelemetry import configure_azure_monitor
+from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
+from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
 
 # pylint: disable=line-too-long
 
@@ -15,21 +19,20 @@ _LOGGING_CONN_STRING_ENTRYPOINT_NAME = "webviz-azure-logging-connection-string"
 
 
 class UsageAnalytics:
-    def __init__(self, telemetry_logger: logging.Logger, user_name: str) -> None:
-        self._telemetry_logger = telemetry_logger
+    def __init__(self, tracer: trace.Tracer, user_name: str) -> None:
+        self._tracer = tracer
         self._user_name = user_name
 
     def log_plugin_usage(self, path_name: str, plugin_name: str) -> None:
-        log_msg = f"PLUGIN_USAGE - plugin_name={plugin_name}, user_name={self._user_name}, path_name={path_name}"
-        # print(f"log_plugin_usage(): {log_msg}")
-
-        extra = {
-            "wv_plugin_name": plugin_name,
-            "wv_user_name": self._user_name,
-            "wv_path_name": path_name,
-        }
-
-        self._telemetry_logger.info(log_msg, extra=extra)
+        with self._tracer.start_as_current_span(
+            "PLUGIN_USAGE",
+            attributes={
+                "wv_plugin_name": plugin_name,
+                "wv_user_name": self._user_name,
+                "wv_path_name": path_name,
+            },
+        ):
+            pass
 
 
 def setup_usage_analytics() -> Optional[UsageAnalytics]:
@@ -71,36 +74,34 @@ def setup_usage_analytics() -> Optional[UsageAnalytics]:
     hostname = _get_hostname()
 
     try:
-        configure_azure_monitor(
-            connection_string=app_insights_connection_string,
-            logger_name="wv_telemetry_logger",
-            sampling_ratio=1.0,
-            resource=Resource.create(
-                attributes={
-                    "service.name": "WebvizDash",
-                    "service.namespace": hostname,
-                    "service.version": wv_config_pkg_version,
-                }
-            ),
-            enable_live_metrics=False,
-            enable_performance_counters=False,
-            # For now, drop the actual flask instrumentation as it doesn't add much value
-            instrumentation_options={"flask": {"enabled": False}},
+        resource = Resource.create(
+            attributes={
+                "service.name": "WebvizDash",
+                "service.namespace": hostname,
+                "service.version": wv_config_pkg_version,
+            }
         )
+
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(
+            BatchSpanProcessor(
+                AzureMonitorTraceExporter(
+                    connection_string=app_insights_connection_string
+                )
+            )
+        )
+        trace.set_tracer_provider(tracer_provider)
+
+        atexit.register(tracer_provider.shutdown)
+
+        tracer = trace.get_tracer("wv_telemetry")
     except Exception as exc:  # pylint: disable=broad-except
         print(
             f"Failed to set up telemetry for usage analytics, proceeding without telemetry. Error: {exc}"
         )
         return None
 
-    telemetry_logger = logging.getLogger("wv_telemetry_logger")
-    telemetry_logger.setLevel(logging.INFO)
-
-    # Don't propagate telemetry logs to the root logger, since that would cause them to be
-    # printed to console by the default logging configuration.
-    telemetry_logger.propagate = False
-
-    return UsageAnalytics(telemetry_logger=telemetry_logger, user_name=username)
+    return UsageAnalytics(tracer=tracer, user_name=username)
 
 
 def _get_connection_string_from_entrypoint() -> Optional[str]:


### PR DESCRIPTION
The package `azure-monitor-opentelemetry` package has a quite big dependency tree. In order to easier support deployment to Komodo, switching to `azure-monitor-opentelemetry-exporter`